### PR TITLE
adds support for `t.eq`

### DIFF
--- a/packages/registry/src/exports.ts
+++ b/packages/registry/src/exports.ts
@@ -1,3 +1,4 @@
+export type * from './satisfies.js'
 export type * from './types.js'
 
 export * as fn from './function.js'

--- a/packages/registry/src/satisfies.ts
+++ b/packages/registry/src/satisfies.ts
@@ -1,0 +1,31 @@
+import type { Primitive } from './types.js'
+
+export type Atoms = [
+  Date,
+  RegExp,
+]
+
+/**
+ * ## {@link Mut `Mut`}
+ * 
+ * @example
+ * declare function defineImmutable<const T>(x: T): T
+ * declare function defineMutable<const T extends Mut<T>>(x: T): T
+ * 
+ * const ex_01 = defineImmutable([1, [2, { x: [3, { y: { z: [4] } } ] } ] ])
+ * const ex_02 = defineMutable([1, [2, { x: [3, { y: { z: [4] } } ] } ] ])
+ * 
+ * ex_01
+ * // ^? const ex_01: readonly [1, readonly [2, readonly [3, { readonly x: readonly [4, { readonly y: { readonly z: readonly [5] } } ] } ] ] ]
+ * 
+ * ex_02
+ * // ^? const ex_02: [1, [2, [3, { x: [4, { y: { z: [5, [6, [7] ] ] } } ] } ] ] ]
+ * 
+ */
+export type Mut<T, Atom = Atoms[number]>
+  = [T] extends [infer U extends Primitive] ? U
+  : [T] extends [infer U extends Atom] ? U
+  : { -readonly [ix in keyof T]: Mut<T[ix], Atom> }
+
+export type Mutable<T> = never | { -readonly [K in keyof T]: T[K] }
+

--- a/packages/schema-zod-adapter/src/exports.ts
+++ b/packages/schema-zod-adapter/src/exports.ts
@@ -1,2 +1,7 @@
 export * from './version.js'
-export { toString } from './functor.js'
+export {
+  fromConstant,
+  fromUnknown,
+  fromConstantToSchemaString,
+  toString,
+} from './functor.js'

--- a/packages/schema/src/functor.ts
+++ b/packages/schema/src/functor.ts
@@ -8,7 +8,7 @@ export const Functor: T.Functor<t.Free, t.Fixpoint> = {
       switch (true) {
         default: return fn.exhaustive(x)
         case t.isLeaf(x): return x
-        case x.tag === URI.eq: return t.Eq.fix(f(x.def))
+        case x.tag === URI.eq: return t.Eq.fix(x.def as never)
         case x.tag === URI.array: return t.Array.fix(f(x.def))
         case x.tag === URI.record: return t.Record.fix(f(x.def))
         case x.tag === URI.optional: return t.Optional.fix(f(x.def))
@@ -20,3 +20,6 @@ export const Functor: T.Functor<t.Free, t.Fixpoint> = {
     }
   }
 }
+
+export const fold = fn.cata(Functor)
+export const unfold = fn.ana(Functor)

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -77,7 +77,6 @@ export declare namespace Type {
   interface Tuple extends T.HKT { [-1]: Items<this[0]> }
   interface Intersect extends T.HKT { [-1]: intersect_<this[0]> }
   interface Union extends T.HKT { [-1]: Unify<this[0]> }
-  // type Map<T> = never | { -readonly [K in keyof T]: Entry<T[K]['_type' & keyof T[K]]> }
   type Unify<T> = never | T[number & keyof T]['_type' & keyof T[number & keyof T]]
   type Properties<
     F,
@@ -135,32 +134,32 @@ export declare namespace t {
 }
 
 export namespace t {
-  export interface Inline<T> { _type: T, tag: URI.inline }
-  export interface Top { _type: unknown, tag: URI.top, }
-  export interface Bottom { _type: never, tag: URI.bottom, }
+  export interface Inline<T> { readonly _type: T, tag: URI.inline }
+  export interface Top { readonly _type: unknown, tag: URI.top, }
+  export interface Bottom { readonly _type: never, tag: URI.bottom, }
 
   export interface InvalidSchema<_Err> extends T.TypeError<''>, t.Never { }
-  export interface Never extends Guard<never>, AST.never { _type: never }
+  export interface Never extends Guard<never>, AST.never { readonly _type: never }
   export const Never: t.Never = Object_assign((u: unknown) => P.never(u), AST.never as t.Never)
-  export interface Unknown extends Guard<unknown>, AST.unknown { _type: unknown }
+  export interface Unknown extends Guard<unknown>, AST.unknown { readonly _type: unknown }
   export const Unknown: t.Unknown = Object_assign((u: unknown): u is unknown => P.any(u), AST.unknown as t.Unknown)
-  export interface Any extends Guard<any>, AST.any { _type: any }
+  export interface Any extends Guard<any>, AST.any { readonly _type: any }
   export const Any: t.Any = Object_assign((u: unknown): u is any => P.any(u), AST.any as t.Any)
-  export interface Void extends Guard<void>, AST.void { _type: void }
+  export interface Void extends Guard<void>, AST.void { readonly _type: void }
   export const Void: t.Void = Object_assign((u: unknown) => P.undefined(u), AST.void as t.Void)
-  export interface Null extends Guard<null>, AST.null { _type: null }
+  export interface Null extends Guard<null>, AST.null { readonly _type: null }
   export const Null: t.Null = Object_assign((u: unknown) => P.null(u), AST.null as t.Null)
-  export interface Undefined extends Guard<undefined>, AST.undefined { _type: undefined }
+  export interface Undefined extends Guard<undefined>, AST.undefined { readonly _type: undefined }
   export const Undefined: t.Undefined = Object_assign((u: unknown) => P.undefined(u), AST.undefined as t.Undefined)
-  export interface BigInt extends Guard<bigint>, AST.bigint { _type: bigint }
+  export interface BigInt extends Guard<bigint>, AST.bigint { readonly _type: bigint }
   export const BigInt: t.BigInt = Object_assign((u: unknown) => P.bigint(u), AST.bigint as t.BigInt)
-  export interface Symbol extends Guard<symbol>, AST.symbol { _type: symbol }
+  export interface Symbol extends Guard<symbol>, AST.symbol { readonly _type: symbol }
   export const Symbol: t.Symbol = Object_assign((u: unknown) => P.symbol(u), AST.symbol as t.Symbol)
-  export interface Boolean extends Guard<boolean>, AST.boolean { _type: boolean }
+  export interface Boolean extends Guard<boolean>, AST.boolean { readonly _type: boolean }
   export const Boolean: t.Boolean = Object_assign((u: unknown) => P.boolean(u), AST.boolean as t.Boolean)
-  export interface Number extends Guard<number>, AST.number { _type: number }
+  export interface Number extends Guard<number>, AST.number { readonly _type: number }
   export const Number: t.Number = Object_assign((u: unknown) => P.number(u), AST.number as t.Number)
-  export interface String extends Guard<string>, AST.string { _type: string }
+  export interface String extends Guard<string>, AST.string { readonly _type: string }
   export const String: t.String = Object_assign((u: unknown) => P.string(u), AST.string as t.String)
 
   export type Leaf = typeof Leaves[number]
@@ -186,18 +185,20 @@ export namespace t {
     typeof u.tag === 'string' &&
     (<string[]>leafTags).includes(u.tag)
 
+  export function Eq<const V>(equalsFn: (value: V) => boolean): t.Eq<V>
   export function Eq<const V extends T.Mut<V>>(value: V): t.Eq<T.Mutable<V>>
+  export function Eq<const V>(value: V): t.Eq<T.Mutable<V>>
   export function Eq(v: {} | null | undefined) { return t.Eq.fix(v) }
   export interface Eq<S = Unspecified> extends t.Eq.def<S> { }
   export namespace Eq {
     export interface def<T, F extends T.HKT = T.Identity> extends AST.eq<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
     export function fix<const T>(x: T): t.Eq.def<T>
     export function fix(x: unknown) {
       return Object_assign(
-        (src: unknown) => equals(src, x),
+        (src: unknown) => typeof x === 'function' ? x(src) : equals(src, x),
         AST.eq(x)
       )
     }
@@ -208,7 +209,7 @@ export namespace t {
   export interface Array<S extends Schema = Unspecified> extends t.Array.def<S> { }
   export namespace Array {
     export interface def<T, F extends T.HKT = Type.Array> extends AST.array<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
     export function fix<F>(p: F): t.Array.def<F>
@@ -225,7 +226,7 @@ export namespace t {
   export interface Record<S extends Schema.Any = Unspecified> extends t.Record.def<S> { }
   export namespace Record {
     export interface def<T, F extends T.HKT = Type.Record> extends AST.record<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
     export function fix<F>(p: F): t.Record.def<F>
@@ -242,7 +243,7 @@ export namespace t {
   export interface Union<S extends readonly Schema[] = readonly Schema[]> extends Union.def<S> { }
   export namespace Union {
     export interface def<T, F extends T.HKT = Type.Union> extends AST.union<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
     export function fix<T extends readonly unknown[]>(ps: T): t.Union.def<T>
@@ -262,7 +263,7 @@ export namespace t {
       T,
       F extends T.HKT = Type.Intersect
     > extends AST.intersect<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
     //
@@ -281,7 +282,7 @@ export namespace t {
   export namespace Optional {
     export interface def<T, F extends T.HKT = Type.Optional> extends
       AST.optional<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
     export function fix<F>(p: F): t.Optional.def<F>
@@ -322,7 +323,7 @@ export namespace t {
 
   export namespace Object {
     export interface def<T, F extends T.HKT = Type.Object> extends AST.object<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
     export type Optionals<S, K extends keyof S = keyof S> =
@@ -359,7 +360,7 @@ export namespace t {
   export interface Tuple<S extends readonly unknown[] = readonly unknown[]> extends Tuple.def<S> { }
   export namespace Tuple {
     export interface def<T, F extends T.HKT = Type.Tuple> extends AST.tuple<T> {
-      _type: T.Kind<F, T>
+      readonly _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
 

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -1,5 +1,6 @@
 import type * as T from '@traversable/registry'
 import { URI } from '@traversable/registry'
+import { Json } from '@traversable/json'
 
 import type {
   Conform,
@@ -122,7 +123,7 @@ export declare namespace t {
 
   type Fixpoint
     = t.Leaf
-    | t.Eq.def<Fixpoint, T.Const>
+    | t.Eq.def<Json, T.Const>
     | t.Array.def<Fixpoint, T.Const>
     | t.Record.def<Fixpoint, T.Const>
     | t.Optional.def<Fixpoint, T.Const>
@@ -185,7 +186,7 @@ export namespace t {
     typeof u.tag === 'string' &&
     (<string[]>leafTags).includes(u.tag)
 
-  export function Eq<V extends {} | null | undefined>(value: V): t.Eq<V>
+  export function Eq<const V extends T.Mut<V>>(value: V): t.Eq<T.Mutable<V>>
   export function Eq(v: {} | null | undefined) { return t.Eq.fix(v) }
   export interface Eq<S = Unspecified> extends t.Eq.def<S> { }
   export namespace Eq {
@@ -193,8 +194,8 @@ export namespace t {
       _type: T.Kind<F, T>
       (u: unknown): u is this['_type']
     }
-    export function fix<T>(x: T): t.Eq.def<T>
-    export function fix<T>(x: T) {
+    export function fix<const T>(x: T): t.Eq.def<T>
+    export function fix(x: unknown) {
       return Object_assign(
         (src: unknown) => equals(src, x),
         AST.eq(x)
@@ -393,6 +394,7 @@ export namespace t {
     bigint: (u: unknown): u is t.BigInt => !!u && typeof u === 'object' && 'tag' in u && u.tag === URI.bigint,
     number: (u: unknown): u is t.Number => !!u && typeof u === 'object' && 'tag' in u && u.tag === URI.number,
     string: (u: unknown): u is t.String => !!u && typeof u === 'object' && 'tag' in u && u.tag === URI.string,
+    eq: <S>(u: S): u is Conform<S, t.Eq<any>, t.Eq> => !!u && typeof u === 'object' && 'tag' in u && u.tag === URI.array,
     array: <S>(u: S): u is Conform<S, t.Array<any>, t.Array> => !!u && typeof u === 'object' && 'tag' in u && u.tag === URI.array,
     record: <S>(u: S): u is Conform<S, t.Record<any>, t.Record> => !!u && typeof u === 'object' && 'tag' in u && u.tag === URI.record,
     optional: <S>(u: S): u is Conform<S, t.Optional<any>, t.Optional> => !!u && typeof u === 'object' && 'tag' in u && u.tag === URI.optional,

--- a/packages/schema/src/recursive.ts
+++ b/packages/schema/src/recursive.ts
@@ -1,15 +1,19 @@
 import type * as T from '@traversable/registry'
 import { fn, NS, URI } from '@traversable/registry'
+import { Json } from '@traversable/json'
 import { t } from './model.js'
 import { parseKey } from '../../registry/src/parse.js'
-import { Functor } from './functor.js'
+import { Functor, fold, unfold } from './functor.js'
 
 /** @internal */
 const Object_entries = globalThis.Object.entries
 /** @internal */
 const OPT = '<<>>' as const
 /** @internal */
-const trim = (s: string) => s.startsWith(OPT) ? s.substring(OPT.length) : s
+const trim = (s?: string) =>
+  s == null ? String(s)
+    : s.startsWith(OPT) ? s.substring(OPT.length)
+      : s
 
 type TypeName<T> = never | T extends `${NS}${infer S}` ? S : never
 function typeName<T extends { tag: string }>(x: T): TypeName<T['tag']>
@@ -17,14 +21,12 @@ function typeName(x: { tag: string }) {
   return x.tag.substring(NS.length)
 }
 
-const serialize = (x: {} | null | undefined): string => ''
-
 export namespace Recursive {
   export const toString: T.Functor.Algebra<t.Free, string> = (x) => {
     switch (true) {
       default: return fn.exhaustive(x)
       case t.isLeaf(x): return 't.' + typeName(x)
-      case x.tag === URI.eq: return x.def // serialize(x.def)
+      case x.tag === URI.eq: return `t.eq(${JSON.stringify(x.def)})`
       case x.tag === URI.array: return `t.${typeName(x)}(${x.def})`
       case x.tag === URI.record: return `t.${typeName(x)}(${x.def})`
       case x.tag === URI.optional: return `t.${typeName(x)}(${x.def})`
@@ -44,26 +46,26 @@ export namespace Recursive {
     switch (true) {
       default: return fn.exhaustive(x)
       case t.isLeaf(x): return typeName(x)
-      case x.tag === URI.eq: return x.def // serialize(x.def)
+      case x.tag === URI.eq: return JSON.stringify(x.def)
       case x.tag === URI.array: return `(${trim(x.def)})[]`
       case x.tag === URI.record: return `Record<string, ${trim(x.def)}>`
       case x.tag === URI.optional: return `${OPT}(${trim(x.def)} | undefined)`
       case x.tag === URI.union: return `(${x.def.map(trim).join(' | ')})`
       case x.tag === URI.intersect: return `(${x.def.map(trim).join(' & ')})`
       case x.tag === URI.tuple:
-        return `[${x.def.map((y) => (y.startsWith(OPT) ? '_?: ' : '') + trim(y)).join(', ')}]`
+        return `[${x.def.map((y) => (y?.startsWith(OPT) ? '_?: ' : '') + trim(y)).join(', ')}]`
       case x.tag === URI.object: {
         const xs = Object_entries(x.def)
         return xs.length === 0
           ? `{}`
-          : `{ ${xs.map(([k, v]) => parseKey(k) + (v.startsWith(OPT) ? '?' : '') + `: ${trim(v)}`).join(', ')} }`
+          : `{ ${xs.map(([k, v]) => parseKey(k) + (v?.startsWith(OPT) ? '?' : '') + `: ${trim(v)}`).join(', ')} }`
       }
     }
   }
 }
 
-export const toString = fn.cata(Functor)(Recursive.toString)
+export const toString = fold(Recursive.toString)
 
 export const toTypeString
   : <S extends t.Fixpoint>(schema: S) => string
-  = (schema) => trim(fn.cata(Functor)(Recursive.toTypeString)(schema))
+  = (schema) => trim(fold(Recursive.toTypeString)(schema))

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -16,6 +16,7 @@ import boolean_ = _.Boolean
 import bigint_ = _.BigInt
 import number_ = _.Number
 import string_ = _.String
+import eq = _.Eq
 import array = _.Array
 import record = _.Record
 import optional = _.Optional
@@ -47,6 +48,7 @@ export declare namespace t {
     bigint_ as bigint,
     number_ as number,
     string_ as string,
+    eq,
     array,
     record,
     optional,
@@ -85,6 +87,7 @@ t.boolean = boolean_
 t.bigint = bigint_
 t.number = number_
 t.string = string_
+t.eq = eq
 t.array = array
 t.record = record
 t.optional = optional

--- a/packages/schema/test/eq.test.ts
+++ b/packages/schema/test/eq.test.ts
@@ -1,0 +1,13 @@
+import * as vi from 'vitest'
+import { fc } from '@fast-check/vitest'
+import * as path from 'node:path'
+import * as fs from 'node:fs'
+
+import { t, Seed } from '@traversable/schema'
+
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema❳: integration tests', () => {
+  vi.it('〖⛳️〗› ❲@traverable/schema❳: it writes', () => {
+    vi.assert.isTrue(true)
+  })
+})

--- a/packages/schema/test/eq.test.ts
+++ b/packages/schema/test/eq.test.ts
@@ -1,13 +1,72 @@
 import * as vi from 'vitest'
-import { fc } from '@fast-check/vitest'
-import * as path from 'node:path'
-import * as fs from 'node:fs'
 
-import { t, Seed } from '@traversable/schema'
+import { t } from '@traversable/schema'
 
+type Sym = typeof Sym
+const Sym = Symbol.for('abc')
 
-vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema❳: integration tests', () => {
-  vi.it('〖⛳️〗› ❲@traverable/schema❳: it writes', () => {
-    vi.assert.isTrue(true)
+const REF = {
+  EmptyArray: [],
+  EmptyObject: {},
+  SingletonObject: { '': void 0 },
+  SingletonArray: [void 0],
+  Symbol: Sym,
+} as const
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema❳', () => {
+  vi.it('〖⛳️〗› ❲t.eq❳: example-based tests', () => {
+    // FAILURE
+    vi.assert.isFalse(t.eq(undefined)(null))
+    vi.assert.isFalse(t.eq(null)(undefined))
+    vi.assert.isFalse(t.eq(Symbol())(undefined))
+    vi.assert.isFalse(t.eq(false)(undefined))
+    vi.assert.isFalse(t.eq(0n)(undefined))
+    vi.assert.isFalse(t.eq(0)(undefined))
+    vi.assert.isFalse(t.eq('')(undefined))
+    vi.assert.isFalse(t.eq([])(undefined))
+    vi.assert.isFalse(t.eq({})(undefined))
+    vi.assert.isFalse(t.eq(Symbol())(Symbol()))
+    vi.assert.isFalse(t.eq(Sym)(Symbol()))
+
+    // SUCCESS
+    vi.assert.isTrue(t.eq(undefined)(undefined))
+    vi.assert.isTrue(t.eq(null)(null))
+    vi.assert.isTrue(t.eq(Sym)(Sym))
+    vi.assert.isTrue(t.eq(false)(false))
+    vi.assert.isTrue(t.eq(0n)(0n))
+    vi.assert.isTrue(t.eq(0)(0))
+    vi.assert.isTrue(t.eq('')(''))
+
+    vi.assert.isTrue(t.eq([])([]))
+    vi.assert.isTrue(t.eq(REF.EmptyArray)(REF.EmptyArray))
+    vi.assert.isTrue(t.eq([])(REF.EmptyArray))
+    vi.assert.isTrue(t.eq(REF.EmptyArray)([]))
+    vi.assert.isTrue(t.eq([void 0])([void 0]))
+    vi.assert.isTrue(t.eq(REF.SingletonArray)(REF.SingletonArray))
+    vi.assert.isTrue(t.eq([void 0])(REF.SingletonArray))
+    vi.assert.isTrue(t.eq(REF.SingletonArray)([void 0]))
+
+    vi.assert.isTrue(t.eq({})({}))
+    vi.assert.isTrue(t.eq(REF.EmptyObject)(REF.EmptyObject))
+    vi.assert.isTrue(t.eq({})(REF.EmptyObject))
+    vi.assert.isTrue(t.eq(REF.EmptyObject)({}))
+
+    vi.assert.isTrue(t.eq({ '': void 0 })({ '': void 0 }))
+    vi.assert.isTrue(t.eq(REF.SingletonObject)(REF.SingletonObject))
+    vi.assert.isTrue(t.eq({ '': void 0 })(REF.SingletonObject))
+    vi.assert.isTrue(t.eq(REF.SingletonObject)({ '': void 0 }))
+  })
+
+  vi.it('〖⛳️〗› ❲t.eq❳: supports passing a custom equals function', () => {
+    const isGoku = t.eq((x: number) => x > 9000)
+    vi.assert.isFalse(isGoku(9000))
+    vi.assert.isTrue(isGoku(9001))
+    vi.assertType<t.eq<number>>(isGoku)
+
+    const isJanet = t.eq((x: { firstName: string }) => x.firstName === 'Janet')
+    vi.assert.isFalse(isJanet({ firstName: 'Bill' }))
+    vi.assert.isFalse(isJanet(9000))
+    vi.assert.isTrue(isJanet({ firstName: 'Janet' }))
+    vi.assertType<t.eq<{ firstName: string }>>(isJanet)
   })
 })

--- a/packages/schema/test/integration.test.ts
+++ b/packages/schema/test/integration.test.ts
@@ -12,6 +12,7 @@ const OPTIONS = {
     array: 0,
     bigint: 0,
     boolean: 0,
+    eq: 0,
     intersect: 0,
     never: -1,
     null: 0,
@@ -48,7 +49,7 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema❳: integration tests',
     `import * as vi from 'vitest'`,
     `import { t } from '@traversable/schema'`
   ] as const satisfies string[]
-  const gen = fc.sample(Seed.schema(), NUM_RUNS)
+  const gen = fc.sample(Seed.schema(OPTIONS), NUM_RUNS)
 
   const deps = [
     'type Equals<S, T> =',
@@ -63,8 +64,7 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema❳: integration tests',
     `//    ^?`,
     `type _${ix + 1} = ${t.toTypeString(schema)}`,
     `vi.assertType<true>(equals<_${ix + 1}>()(_${ix + 1}._type))`,
-  ].join('\n') + '\n'
-  )
+  ].join('\n') + '\n')
 
   // const types = gen.map((schema) => t.toTypeString(schema))
   const out = [

--- a/packages/schema/test/model.test.ts
+++ b/packages/schema/test/model.test.ts
@@ -69,9 +69,11 @@ const ZodNullaryMap = {
 }
 
 const zodAlgebra: Functor.Algebra<Seed.Free, z.ZodTypeAny> = (x) => {
+  if (!Seed.isSeed(x)) return x as never
   switch (true) {
     default: return fn.exhaustive(x)
     case Seed.isNullary(x): return ZodNullaryMap[x[0]]
+    case x[0] === URI.eq: return zod.fromConstant(x[1] as never)
     case x[0] === URI.optional: return z.optional(x[1])
     case x[0] === URI.array: return z.array(x[1])
     case x[0] === URI.tuple: return z.tuple([x[1][0], ...x[1].slice(1)])

--- a/packages/schema/test/seed.test.ts
+++ b/packages/schema/test/seed.test.ts
@@ -109,30 +109,30 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/seed❳', () => {
 })
 
 vi.describe('eq', () => {
-  vi.it('〖⛳️〗› ❲Seed#eqToJson❳', () => {
-    vi.assert.isNull(Seed.eqToJson([URI.eq, [URI.null]]))
-    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.any]]))
-    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.never]]))
-    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.unknown]]))
-    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.unknown]]))
-    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.undefined]]))
-    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.undefined]]))
-    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.boolean]]), false)
-    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.symbol_]]), 'Symbol()')
-    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.number]]), 0)
-    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.bigint]]), 0)
-    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.string]]), '')
-    vi.assert.deepEqual(Seed.eqToJson([URI.array, [URI.eq, [URI.null]]]), [])
-    vi.assert.deepEqual(Seed.eqToJson([URI.tuple, [[URI.eq, [URI.null]]]]), [null])
-    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['abc', [URI.null]]]]), { abc: null })
-    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['abc', [URI.eq, [URI.null]]]]]), { abc: null })
-    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]), { abc: [0] })
-    vi.assert.deepEqual(Seed.eqToJson([URI.eq, [URI.eq, [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]), { abc: [0] })
-    vi.assert.deepEqual(Seed.eqToJson([URI.eq, [URI.eq, [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]), { abc: [0] })
-    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['xyz', [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]]), { xyz: { abc: [0] } })
-    vi.assert.deepEqual(Seed.eqToJson([URI.intersect, []]), {})
+  vi.it('〖⛳️〗› ❲Seed#toJson❳', () => {
+    vi.assert.isNull(Seed.toJson([URI.eq, [URI.null]]))
+    vi.assert.isUndefined(Seed.toJson([URI.eq, [URI.any]]))
+    vi.assert.isUndefined(Seed.toJson([URI.eq, [URI.never]]))
+    vi.assert.isUndefined(Seed.toJson([URI.eq, [URI.unknown]]))
+    vi.assert.isUndefined(Seed.toJson([URI.eq, [URI.unknown]]))
+    vi.assert.isUndefined(Seed.toJson([URI.eq, [URI.undefined]]))
+    vi.assert.isUndefined(Seed.toJson([URI.eq, [URI.undefined]]))
+    vi.assert.equal(Seed.toJson([URI.eq, [URI.boolean]]), false)
+    vi.assert.equal(Seed.toJson([URI.eq, [URI.symbol_]]), 'Symbol()')
+    vi.assert.equal(Seed.toJson([URI.eq, [URI.number]]), 0)
+    vi.assert.equal(Seed.toJson([URI.eq, [URI.bigint]]), 0)
+    vi.assert.equal(Seed.toJson([URI.eq, [URI.string]]), '')
+    vi.assert.deepEqual(Seed.toJson([URI.array, [URI.eq, [URI.null]]]), [])
+    vi.assert.deepEqual(Seed.toJson([URI.tuple, [[URI.eq, [URI.null]]]]), [null])
+    vi.assert.deepEqual(Seed.toJson([URI.object, [['abc', [URI.null]]]]), { abc: null })
+    vi.assert.deepEqual(Seed.toJson([URI.object, [['abc', [URI.eq, [URI.null]]]]]), { abc: null })
+    vi.assert.deepEqual(Seed.toJson([URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]), { abc: [0] })
+    vi.assert.deepEqual(Seed.toJson([URI.eq, [URI.eq, [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]), { abc: [0] })
+    vi.assert.deepEqual(Seed.toJson([URI.eq, [URI.eq, [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]), { abc: [0] })
+    vi.assert.deepEqual(Seed.toJson([URI.object, [['xyz', [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]]), { xyz: { abc: [0] } })
+    vi.assert.deepEqual(Seed.toJson([URI.intersect, []]), {})
     vi.assert.deepEqual(
-      Seed.eqToJson([
+      Seed.toJson([
         URI.intersect, [
           [URI.object, [['x', [URI.null]]]],
           [URI.object, [['y', [URI.string]]]],
@@ -146,10 +146,10 @@ vi.describe('eq', () => {
       }
     )
 
-    vi.assert.deepEqual(Seed.eqToJson([URI.union, []]), void 0)
+    vi.assert.deepEqual(Seed.toJson([URI.union, []]), void 0)
 
     vi.assert.deepEqual(
-      Seed.eqToJson([
+      Seed.toJson([
         URI.union, [
           [URI.object, [['x', [URI.null]]]],
           [URI.object, [['y', [URI.string]]]],
@@ -160,7 +160,7 @@ vi.describe('eq', () => {
     )
 
     vi.assert.deepEqual(
-      Seed.eqToJson([
+      Seed.toJson([
         URI.eq, [
           URI.object, [
             [

--- a/packages/schema/test/seed.test.ts
+++ b/packages/schema/test/seed.test.ts
@@ -105,4 +105,105 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/seed❳', () => {
     const ex_03 = ([t.optional(t.never), t.string, t.number] as t.Fixpoint[]).sort(Seed.sortOptionalsLast)
     vi.assert.deepEqual(ex_03.map((ex) => ex.tag), [URI.string, URI.number, URI.optional])
   })
+
+})
+
+vi.describe('eq', () => {
+  vi.it('〖⛳️〗› ❲Seed#eqToJson❳', () => {
+    vi.assert.isNull(Seed.eqToJson([URI.eq, [URI.null]]))
+    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.any]]))
+    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.never]]))
+    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.unknown]]))
+    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.unknown]]))
+    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.undefined]]))
+    vi.assert.isUndefined(Seed.eqToJson([URI.eq, [URI.undefined]]))
+    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.boolean]]), false)
+    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.symbol_]]), 'Symbol()')
+    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.number]]), 0)
+    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.bigint]]), 0)
+    vi.assert.equal(Seed.eqToJson([URI.eq, [URI.string]]), '')
+    vi.assert.deepEqual(Seed.eqToJson([URI.array, [URI.eq, [URI.null]]]), [])
+    vi.assert.deepEqual(Seed.eqToJson([URI.tuple, [[URI.eq, [URI.null]]]]), [null])
+    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['abc', [URI.null]]]]), { abc: null })
+    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['abc', [URI.eq, [URI.null]]]]]), { abc: null })
+    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]), { abc: [0] })
+    vi.assert.deepEqual(Seed.eqToJson([URI.eq, [URI.eq, [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]), { abc: [0] })
+    vi.assert.deepEqual(Seed.eqToJson([URI.eq, [URI.eq, [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]), { abc: [0] })
+    vi.assert.deepEqual(Seed.eqToJson([URI.object, [['xyz', [URI.object, [['abc', [URI.eq, [URI.tuple, [[URI.number]]]]]]]]]]), { xyz: { abc: [0] } })
+    vi.assert.deepEqual(Seed.eqToJson([URI.intersect, []]), {})
+    vi.assert.deepEqual(
+      Seed.eqToJson([
+        URI.intersect, [
+          [URI.object, [['x', [URI.null]]]],
+          [URI.object, [['y', [URI.string]]]],
+          [URI.object, [['z', [URI.boolean]]]],
+        ]
+      ]),
+      {
+        x: null,
+        y: '',
+        z: false,
+      }
+    )
+
+    vi.assert.deepEqual(Seed.eqToJson([URI.union, []]), void 0)
+
+    vi.assert.deepEqual(
+      Seed.eqToJson([
+        URI.union, [
+          [URI.object, [['x', [URI.null]]]],
+          [URI.object, [['y', [URI.string]]]],
+          [URI.object, [['z', [URI.boolean]]]],
+        ]
+      ]),
+      { x: null }
+    )
+
+    vi.assert.deepEqual(
+      Seed.eqToJson([
+        URI.eq, [
+          URI.object, [
+            [
+              'x', [
+                URI.eq, [
+                  URI.object, [
+                    ['a', [URI.eq, [URI.tuple, [[URI.eq, [URI.number]]]]]],
+                    ['b', [URI.tuple, [[URI.eq, [URI.string]]]]],
+                    ['c', [URI.object, [['d', [URI.tuple, [[URI.eq, [URI.union, [[URI.void]]]]]]]]]],
+                  ]
+                ]
+              ]
+            ],
+            [
+              'y', [
+                URI.eq, [
+                  URI.object, [
+                    ['e', [URI.eq, [URI.intersect, [
+                      [URI.eq, [URI.object, [['h', [URI.eq, [URI.string]]]]]],
+                      [URI.eq, [URI.object, [['h', [URI.eq, [URI.number]]]]]],
+                    ]]]],
+                    ['f', [URI.eq, [URI.eq, [URI.eq, [URI.number]]]]],
+                    ['g', [URI.eq, [URI.tuple, [[URI.eq, [URI.number]]]]]],
+                  ]
+                ]
+              ]
+            ]
+          ],
+        ]
+      ]),
+      {
+        x: {
+          a: [0],
+          b: [""],
+          c: { d: [undefined] },
+        },
+        y: {
+          e: { h: 0 },
+          f: 0,
+          g: [0],
+        }
+      }
+    )
+  })
+
 })


### PR DESCRIPTION
Added for interop with JSON Schema's `const` keyword. Adapter to/from zod should be working but haven't written property tests for it yet.

When adapting to/from zod, the value is parsed into a zod schema, e.g.:

```typescript
t.object({ root: t.eq({ a: 1, b: [2, 3] }) })
```

becomes:

```typescript
z.object({
  root: z.object({
    a: z.literal(1), 
    b: z.tuple([
      z.literal(2), 
      z.literal(3),
    ]) 
  })
})
```

Example usage:

```typescript
import { t } from '@traversable/schema'


const isZero = t.eq(0)
//     ^? const isZero: t.eq<0>

console.log(isZero(0))         // true
console.log(isZero([1, 2, 3])) // false


const isJanet = t.eq({ firstName: 'Janet' })
//     ^? const isJanet: t.eq<{ firstName: 'Janet' }>

console.log(isJanet({ firstName: 'Bill' }))  // => false
console.log(isJanet({ firstName: 'Janet' })) // => true
console.log(isJanet([1, 2, 3]))              // => false
```