### PR TITLE
fix(schema): re-exports `schema`, `schema.any` from `schema-core`

### DIFF
--- a/.changeset/bitter-tables-sell.md
+++ b/.changeset/bitter-tables-sell.md
@@ -1,0 +1,6 @@
+---
+"@traversable/schema-core": patch
+"@traversable/schema": patch
+---
+
+chore(schema): re-exports Schema.any from `schema-core`

--- a/packages/schema-core/src/schema.ts
+++ b/packages/schema-core/src/schema.ts
@@ -1,4 +1,4 @@
-import type { Schema, AnySchema } from './core.js'
+import type { AnySchema, Schema, Unspecified } from './core.js'
 import { t as _, typeOf } from './core.js'
 import { Functor, fold, unfold } from './functor.js'
 import { is } from './is.js'
@@ -76,8 +76,10 @@ export declare namespace t {
     is,
     Leaf,
     Schema,
+    Unspecified,
   }
 }
+
 t.never = never_
 t.unknown = unknown_
 t.any = any_

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -24,6 +24,7 @@ import intersect = _.intersect
 
 import Functor = _.Functor
 import Free = _.Free
+
 import Leaf = _.Leaf
 import F = _.F
 import Fixpoint = _.Fixpoint
@@ -33,12 +34,17 @@ import top = _.top
 import InvalidSchema = _.InvalidSchema
 import is = _.is
 
-interface void_ extends _.void { }
-interface null_ extends _.null { }
 const void_ = _.void
 const null_ = _.null
 
+
 type typeOf<T extends { _type?: unknown }> = _.typeof<T>
+interface void_ extends _.void { }
+interface null_ extends _.null { }
+interface Any extends _.AnySchema { }
+interface Schema<S extends Schema.any = Schema.Unspecified> extends _.Schema<S> { }
+interface Unspecified extends _.Unspecified { }
+declare namespace Schema { export { Any as any, Unspecified } }
 
 export declare namespace t {
   export {
@@ -77,6 +83,7 @@ export declare namespace t {
     InvalidSchema,
     is,
     Leaf,
+    Schema as schema,
     toString,
     toTypeString,
   }


### PR DESCRIPTION
Closes #36 

Re-exporting so the types flow through