### PR TITLE
init(codec): adds `Codec` feature for BFF / middleware use case

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,5 @@
   "linked": [],
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@traversable/bin", "@traversable/examples"]
+  "ignore": []
 }

--- a/.changeset/shy-pumas-jump.md
+++ b/.changeset/shy-pumas-jump.md
@@ -1,0 +1,110 @@
+---
+"@traversable/schema-codec": patch
+---
+
+init(codec): adds `@traversable/schema-codec` package
+
+## new packages
+
+- `@traversable/schema-codec`
+
+  This package allows users to promote a schema from `@traversable/schema` or `@traversable/schema-core` to being a _codec_.
+
+  A traversable codec is a bi-directional decoder + encoder pair. It was specifically designed for the "BFF" or "middleware"
+  use case.
+
+  All codecs include `.pipe` and `.extend` instance methods that allow users to "stack" an arbitrary number of encodings / decodings.
+
+  ### Example
+
+  ```typescript
+  import * as vi from 'vitest'
+  import { Codec } from '@traversable/schema-codec'
+
+  interface ApiResponse { data: t.typeof<typeof ServerUser> }
+
+  const ServerUser = t.object({
+    createdAt: t.string,
+    updatedAt: t.string,
+  })
+
+  interface ClientUser {
+    id: number
+    createdAt: Date
+    updatedAt: Date
+  }
+
+  const myCodec = Codec
+    .new(ServerUser)
+    .pipe((user) => ({ ...user, id: makeId() }))
+    .unpipe(({ id, ...user }) => user)
+    .pipe((user): ClientUser => ({ ...user, createdAt: new Date(user.createdAt), updatedAt: new Date(user.updatedAt) }))
+    .unpipe((user) => ({ ...user, createdAt: user.createdAt.toISOString(), updatedAt: user.updatedAt.toISOString() }))
+    .extend((fromAPI: ApiResponse) => fromAPI.data)
+    .unextend((data) => ({ data }))
+
+  type MyCodec = typeof myCodec
+  //   ^? type MyCodec = Codec<ApiResponse, ClientUser>
+
+  const createdAt = new Date(2021, 0, 31)
+  const updatedAt = new Date()
+
+  const clientUser = { id: 0, createdAt, updatedAt } satisfies ClientUser
+
+  const serverResponse = {
+    data: {
+      createdAt: createdAt.toISOString(),
+      updatedAt: updatedAt.toISOString(),
+    }
+  }
+
+  vi.test('codec satisfies the roundtrip property', () => {
+    vi.assert.deepEqual(myCodec.decode(serverResponse), clientUser)
+    vi.assert.deepEqual(myCodec.encode(myCodec.decode(serverResponse)), serverResponse)
+    vi.assert.deepEqual(myCodec.decode(myCodec.encode(myCodec.decode(serverResponse))), clientUser)
+  })
+  ```
+
+  #### `.pipe`
+
+  If you've used `zod` before, `z.transform` is a special case of `.pipe`.
+
+  Differences between `.pipe` and `z.transform`:
+
+  - `.pipe` uses the builder pattern (here's a nice [introductory video by Andrew Burgess](https://www.youtube.com/watch?v=AON1nirWpcc)
+    if you're unfamiliar with the pattern), so users can simply chain
+
+  - Supports the inverse
+    - Almost always, when you use `z.transform`, you end up needing to "unapply" the transformation
+
+  - Fewer edge cases / bugs
+    - As of March 2025, of the 1500 issues opened against the Zod repository, 
+      [1 in 6](https://github.com/colinhacks/zod/issues?q=is%3Aissue%20state%3Aopen%20transform) involve
+      `z.transform`.
+    - If you dig into those issues, you'll see that they mostly involve _nested_ transforms
+      
+  - More composable
+    - Because 
+
+  - Better theoretical foundation
+    
+    This ties into "More composable" above:
+
+    - The `@traversable/schema` codec was inspired by PureScript's 
+      [lens encoding](https://pursuit.purescript.org/packages/purescript-profunctor-lenses/8.0.0),
+      which have several advantages over the van Laarhoven encoding found in most functional languages.
+      The profunctor encoding was chosen `@traversable/schema-codec` because like our schemas,
+      profunctor optics _are just functions_.
+
+  #### `.extend`
+
+  - The `.extend` method works just like `.pipe`, except in reverse: instead of mapping _to_ a new target,
+    you "extend" _from_ a new source.
+
+    This can be pretty tricky to implement in userland, since types work 
+    [exactly backwards](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html)
+    from the way they do normally.
+
+    The use case for `.extend` is typically when you need to extend to preprocess data __before__ it enters
+    its "canonical" form.
+    

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ flowchart TD
     schema-valibot-adapter(@traversable/schema-valibot-adapter) -.-> registry(@traversable/registry)
     schema-zod-adapter(@traversable/schema-zod-adapter) -.-> json(@traversable/json)
     schema-zod-adapter(@traversable/schema-zod-adapter) -.-> registry(@traversable/registry)
+    schema-codec(@traversable/schema-codec) -.-> registry(@traversable/registry)
+    schema-codec(@traversable/schema-codec) -.-> schema-core(@traversable/schema-core)
     schema-seed(@traversable/schema-seed) -.-> json(@traversable/json)
     schema-seed(@traversable/schema-seed) -.-> registry(@traversable/registry)
     schema-seed(@traversable/schema-seed) -.-> schema-core(@traversable/schema-core)

--- a/config/__generated__/package-list.ts
+++ b/config/__generated__/package-list.ts
@@ -3,6 +3,7 @@ export const PACKAGES = [
   "packages/json",
   "packages/registry",
   "packages/schema",
+  "packages/schema-codec",
   "packages/schema-core",
   "packages/schema-seed",
   "packages/schema-valibot-adapter",

--- a/packages/schema-codec/README.md
+++ b/packages/schema-codec/README.md
@@ -1,0 +1,1 @@
+# @traversable/schema-codec

--- a/packages/schema-codec/README.md
+++ b/packages/schema-codec/README.md
@@ -1,1 +1,102 @@
 # @traversable/schema-codec
+
+This package allows users to promote a schema from `@traversable/schema` or `@traversable/schema-core` to being a _codec_.
+
+A traversable codec is a bi-directional decoder + encoder pair. It was specifically designed for the "BFF" or "middleware"
+use case.
+
+All codecs include `.pipe` and `.extend` instance methods that allow users to "stack" an arbitrary number of encodings / decodings.
+
+### Example
+
+```typescript
+import * as vi from 'vitest'
+import { Codec } from '@traversable/schema-codec'
+
+interface ApiResponse { data: t.typeof<typeof ServerUser> }
+
+const ServerUser = t.object({
+  createdAt: t.string,
+  updatedAt: t.string,
+})
+
+interface ClientUser {
+  id: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+const myCodec = Codec
+  .new(ServerUser)
+  .pipe((user) => ({ ...user, id: makeId() }))
+  .unpipe(({ id, ...user }) => user)
+  .pipe((user): ClientUser => ({ ...user, createdAt: new Date(user.createdAt), updatedAt: new Date(user.updatedAt) }))
+  .unpipe((user) => ({ ...user, createdAt: user.createdAt.toISOString(), updatedAt: user.updatedAt.toISOString() }))
+  .extend((fromAPI: ApiResponse) => fromAPI.data)
+  .unextend((data) => ({ data }))
+
+type MyCodec = typeof myCodec
+//   ^? type MyCodec = Codec<ApiResponse, ClientUser>
+
+const createdAt = new Date(2021, 0, 31)
+const updatedAt = new Date()
+
+const clientUser = { id: 0, createdAt, updatedAt } satisfies ClientUser
+
+const serverResponse = {
+  data: {
+    createdAt: createdAt.toISOString(),
+    updatedAt: updatedAt.toISOString(),
+  }
+}
+
+vi.test('codec satisfies the roundtrip property', () => {
+  vi.assert.deepEqual(myCodec.decode(serverResponse), clientUser)
+  vi.assert.deepEqual(myCodec.encode(myCodec.decode(serverResponse)), serverResponse)
+  vi.assert.deepEqual(myCodec.decode(myCodec.encode(myCodec.decode(serverResponse))), clientUser)
+})
+```
+
+#### `.pipe`
+
+If you've used `zod` before, `z.transform` is a special case of `.pipe`.
+
+Differences between `.pipe` and `z.transform`:
+
+- `.pipe` uses the builder pattern (here's a nice [introductory video by Andrew Burgess](https://www.youtube.com/watch?v=AON1nirWpcc)
+  if you're unfamiliar with the pattern), so users can simply chain
+
+- Supports the inverse
+  - Almost always, when you use `z.transform`, you end up needing to "unapply" the transformation
+
+- Fewer edge cases / bugs
+  - As of March 2025, of the 1500 issues opened against the Zod repository, 
+    [1 in 6](https://github.com/colinhacks/zod/issues?q=is%3Aissue%20state%3Aopen%20transform) involve
+    `z.transform`.
+  - If you dig into those issues, you'll see that they mostly involve _nested_ transforms
+    
+- More composable
+  - Because 
+
+- Better theoretical foundation
+  
+  This ties into "More composable" above:
+
+  - The `@traversable/schema` codec was inspired by PureScript's 
+    [lens encoding](https://pursuit.purescript.org/packages/purescript-profunctor-lenses/8.0.0),
+    which have several advantages over the van Laarhoven encoding found in most functional languages.
+    The profunctor encoding was chosen `@traversable/schema-codec` because like our schemas,
+    profunctor optics _are just functions_.
+
+#### `.extend`
+
+- The `.extend` method works just like `.pipe`, except in reverse: instead of mapping _to_ a new target,
+  you "extend" _from_ a new source.
+
+  This can be pretty tricky to implement in userland, since types work 
+  [exactly backwards](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html)
+  from the way they do normally.
+
+  The use case for `.extend` is typically when you need to extend to preprocess data __before__ it enters
+  its "canonical" form.
+  

--- a/packages/schema-codec/package.json
+++ b/packages/schema-codec/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@traversable/schema-codec",
+  "type": "module",
+  "version": "0.0.0",
+  "private": false,
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/traversable/schema.git",
+    "directory": "packages/schema-codec"
+  },
+  "bugs": {
+    "url": "https://github.com/traversable/schema/issues",
+    "email": "ahrjarrett@gmail.com"
+  },
+  "@traversable": {
+    "generateExports": { "include": ["**/*.ts"] },
+    "generateIndex": { "include": ["**/*.ts"] }
+  },
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "bench": "echo NOTHING TO BENCH",
+    "build": "pnpm build:esm && pnpm build:cjs && pnpm build:annotate",
+    "build:annotate": "babel build --plugins annotate-pure-calls --out-dir build --source-maps",
+    "build:esm": "tsc -b tsconfig.build.json",
+    "build:cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "clean": "pnpm run \"/^clean:.*/\"",
+    "clean:build": "rm -rf .tsbuildinfo dist build",
+    "clean:deps": "rm -rf node_modules",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "@traversable/registry": "workspace:^",
+    "@traversable/schema-core": "workspace:^"
+  },
+  "devDependencies": {
+    "@traversable/registry": "workspace:^",
+    "@traversable/schema-core": "workspace:^"
+  }
+}

--- a/packages/schema-codec/src/__generated__/__manifest__.ts
+++ b/packages/schema-codec/src/__generated__/__manifest__.ts
@@ -1,0 +1,41 @@
+export default {
+  "name": "@traversable/schema-codec",
+  "type": "module",
+  "version": "0.0.0",
+  "private": false,
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/traversable/schema.git",
+    "directory": "packages/schema-codec"
+  },
+  "bugs": {
+    "url": "https://github.com/traversable/schema/issues",
+    "email": "ahrjarrett@gmail.com"
+  },
+  "@traversable": {
+    "generateExports": { "include": ["**/*.ts"] },
+    "generateIndex": { "include": ["**/*.ts"] }
+  },
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "bench": "echo NOTHING TO BENCH",
+    "build": "pnpm build:esm && pnpm build:cjs && pnpm build:annotate",
+    "build:annotate": "babel build --plugins annotate-pure-calls --out-dir build --source-maps",
+    "build:esm": "tsc -b tsconfig.build.json",
+    "build:cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "clean": "pnpm run \"/^clean:.*/\"",
+    "clean:build": "rm -rf .tsbuildinfo dist build",
+    "clean:deps": "rm -rf node_modules",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "@traversable/registry": "workspace:^",
+    "@traversable/schema-core": "workspace:^"
+  },
+  "devDependencies": {
+    "@traversable/registry": "workspace:^",
+    "@traversable/schema-core": "workspace:^"
+  }
+} as const

--- a/packages/schema-codec/src/codec.ts
+++ b/packages/schema-codec/src/codec.ts
@@ -1,0 +1,67 @@
+import { t } from '@traversable/schema-core'
+
+/** @internal */
+interface Internal {
+  from: ((_: any) => unknown)[]
+  to: ((_: any) => unknown)[]
+  $: unknown
+}
+
+/** @internal */
+interface Pipe<S, T, A extends t.Schema<t.AnySchema>, B> { unpipe(mapBack: (b: B) => T): Codec<S, B, A> }
+
+/** @internal */
+interface Extend<S, T, A extends t.Schema<t.AnySchema>, B> { unextend(mapBack: (s: S) => B): Codec<B, T, A> }
+
+export class Codec<S, T, A extends t.Schema<t.AnySchema>> {
+  static new
+    : <S extends t.Schema<t.AnySchema>>(schema: S) => Codec<S['_type'], S['_type'], S>
+    = (schema) => new Codec(schema)
+
+  decode(source: S): T
+  decode(source: S) {
+    this._.$ = source
+    for (let ix = 0, len = this._.to.length; ix < len; ix++) {
+      const f = this._.to[ix]
+      this._.$ = f(this._.$)
+    }
+    return this._.$
+  }
+
+  encode(target: T): S
+  encode(target: T) {
+    this._.$ = target
+    for (let ix = this._.from.length; ix-- !== 0;) {
+      const f = this._.from[ix]
+      this._.$ = f(this._.$)
+    }
+    return this._.$
+  }
+
+  extend<B>(premap: (b: B) => S): Extend<S, T, A, B> {
+    return {
+      unextend: (mapBack) => new Codec(
+        this.schema, {
+        to: [premap, ...this._.to],
+        from: [mapBack, ...this._.from],
+        $: void 0,
+      })
+    }
+  }
+
+  pipe<B>(map: (t: T) => B): Pipe<S, T, A, B> {
+    return {
+      unpipe: (unmap) => new Codec(
+        this.schema, {
+        to: [...this._.to, map],
+        from: [...this._.from, unmap],
+        $: void 0,
+      })
+    }
+  }
+
+  private constructor(
+    public schema: A,
+    private _: Internal = { from: [], to: [], $: void 0 }
+  ) { }
+}

--- a/packages/schema-codec/src/exports.ts
+++ b/packages/schema-codec/src/exports.ts
@@ -1,0 +1,2 @@
+export { VERSION } from './version.js'
+export { Codec } from './codec.js'

--- a/packages/schema-codec/src/index.ts
+++ b/packages/schema-codec/src/index.ts
@@ -1,0 +1,2 @@
+export * from './exports.js'
+export * as codec from './exports.js'

--- a/packages/schema-codec/src/version.ts
+++ b/packages/schema-codec/src/version.ts
@@ -1,0 +1,3 @@
+import pkg from './__generated__/__manifest__.js'
+export const VERSION = `${pkg.name}@${pkg.version}` as const
+export type VERSION = typeof VERSION

--- a/packages/schema-codec/test/codec.test.ts
+++ b/packages/schema-codec/test/codec.test.ts
@@ -1,0 +1,53 @@
+import * as vi from 'vitest'
+
+import { Codec } from '@traversable/schema-codec'
+import { t } from '@traversable/schema-core'
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/config❳', () => {
+  vi.it('〖⛳️〗› ❲config#configure❳', () => {
+    type ServerUser = t.typeof<typeof ServerUser>
+    const ServerUser = t.object({
+      createdAt: t.string,
+      updatedAt: t.string,
+    })
+
+    type ClientUser = {
+      id: number
+      createdAt: Date
+      updatedAt: Date
+    }
+
+    const id = 0
+    const createdAt = new Date(2021, 0, 31)
+    const updatedAt = new Date()
+
+    const clientUser = {
+      id,
+      createdAt,
+      updatedAt,
+    } satisfies ClientUser
+
+    const serverResponse = [{
+      data: {
+        createdAt: createdAt.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      }
+    }] satisfies [any]
+
+    const codec_01 = Codec
+      .new(ServerUser)
+      .extend(({ data }: { data: ServerUser }) => data)
+      .unextend((_) => ({ data: _ }))
+      .extend(([_]: [{ data: ServerUser }]) => _)
+      .unextend((_) => [_])
+      .pipe(($) => ({ ...$, id }))
+      .unpipe(({ id, ...$ }) => $)
+      .pipe(($) => ({ ...$, createdAt: new Date($.createdAt), updatedAt: new Date($.updatedAt) }))
+      .unpipe(($) => ({ ...$, createdAt: $.createdAt.toISOString(), updatedAt: $.updatedAt.toISOString() }))
+
+    vi.assert.deepEqual(codec_01.decode(serverResponse), clientUser)
+    vi.assert.deepEqual(codec_01.encode(codec_01.decode(serverResponse)), serverResponse)
+    vi.assert.deepEqual(codec_01.decode(codec_01.encode(codec_01.decode(serverResponse))), clientUser)
+    vi.assert.deepEqual(codec_01.encode(codec_01.decode(codec_01.encode(codec_01.decode(serverResponse)))), serverResponse)
+  })
+})

--- a/packages/schema-codec/test/version.test.ts
+++ b/packages/schema-codec/test/version.test.ts
@@ -1,0 +1,10 @@
+import * as vi from 'vitest'
+import pkg from '../package.json'
+import { VERSION } from '@traversable/schema-codec'
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traversable/schema-codec❳', () => {
+  vi.it('〖⛳️〗› ❲schemaCodec#VERSION❳', () => {
+    const expected = `${pkg.name}@${pkg.version}`
+    vi.assert.equal(VERSION, expected)
+  })
+})

--- a/packages/schema-codec/tsconfig.build.json
+++ b/packages/schema-codec/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "types": ["node"],
+    "declarationDir": "build/dts",
+    "outDir": "build/esm",
+    "stripInternal": true
+  },
+  "references": [{ "path": "../registry" }, { "path": "../schema-core" }]
+}

--- a/packages/schema-codec/tsconfig.json
+++ b/packages/schema-codec/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages/schema-codec/tsconfig.src.json
+++ b/packages/schema-codec/tsconfig.src.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "types": ["node"],
+    "outDir": "build/src"
+  },
+  "references": [{ "path": "../registry" }, { "path": "../schema-core" }],
+  "include": ["src"]
+}

--- a/packages/schema-codec/tsconfig.test.json
+++ b/packages/schema-codec/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "types": ["node"],
+    "noEmit": true
+  },
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "../registry" },
+    { "path": "../schema-core" }
+  ],
+  "include": ["test"]
+}

--- a/packages/schema-codec/vite.config.ts
+++ b/packages/schema-codec/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import sharedConfig from '../../vite.config.js'
+
+const localConfig = defineConfig({})
+
+export default mergeConfig(sharedConfig, localConfig)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,15 @@ importers:
         version: 3.24.2
     publishDirectory: dist
 
+  packages/schema-codec:
+    devDependencies:
+      '@traversable/registry':
+        specifier: workspace:^
+        version: link:../registry/dist
+      '@traversable/schema-core':
+        specifier: workspace:^
+        version: link:../schema-core/dist
+
   packages/schema-core:
     devDependencies:
       '@traversable/json':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -35,6 +35,8 @@
       "@traversable/registry": ["packages/registry/src/index.js"],
       "@traversable/registry/*": ["packages/registry/*.js"],
       "@traversable/schema": ["packages/schema/src/index.js"],
+      "@traversable/schema-codec": ["packages/schema-codec/src/index.js"],
+      "@traversable/schema-codec/*": ["packages/schema-codec/*.js"],
       "@traversable/schema-core": ["packages/schema-core/src/index.js"],
       "@traversable/schema-core/*": ["packages/schema-core/*.js"],
       "@traversable/schema-seed": ["packages/schema-seed/src/index.js"],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,6 +5,7 @@
     { "path": "packages/derive-equals/tsconfig.build.json" },
     { "path": "packages/json/tsconfig.build.json" },
     { "path": "packages/registry/tsconfig.build.json" },
+    { "path": "packages/schema-codec/tsconfig.build.json" },
     { "path": "packages/schema-core/tsconfig.build.json" },
     { "path": "packages/schema-seed/tsconfig.build.json" },
     { "path": "packages/schema-valibot-adapter/tsconfig.build.json" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "packages/json" },
     { "path": "packages/registry" },
     { "path": "packages/schema" },
+    { "path": "packages/schema-codec" },
     { "path": "packages/schema-core" },
     { "path": "packages/schema-seed" },
     { "path": "packages/schema-valibot-adapter" },


### PR DESCRIPTION
Closes #42

This PR adds a new package, `@traversable/schema-codec`, a modular / opt-in feature that allows users to promote their schemas to be full-fledge adapters.

This feature was simple to implement, clocking in at a total of 70 lines of unminified code (should be less than 0.25 kb zgipped).

For more in-depth notes, refer to the changelog or `@traversable/schema-codec`'s README.

### example

```typescript
  import * as vi from 'vitest'
  import { Codec } from '@traversable/schema-codec'

  interface ApiResponse { data: t.typeof<typeof ServerUser> }

  const ServerUser = t.object({
    createdAt: t.string,
    updatedAt: t.string,
  })

  interface ClientUser {
    id: number
    createdAt: Date
    updatedAt: Date
  }

  const myCodec = Codec
    .new(ServerUser)
    .pipe((user) => ({ ...user, id: makeId() }))
    .unpipe(({ id, ...user }) => user)
    .pipe((user): ClientUser => ({ ...user, createdAt: new Date(user.createdAt), updatedAt: new Date(user.updatedAt) }))
    .unpipe((user) => ({ ...user, createdAt: user.createdAt.toISOString(), updatedAt: user.updatedAt.toISOString() }))
    .extend((fromAPI: ApiResponse) => fromAPI.data)
    .unextend((data) => ({ data }))

  type MyCodec = typeof myCodec
  //   ^? type MyCodec = Codec<ApiResponse, ClientUser>

  const createdAt = new Date(2021, 0, 31)
  const updatedAt = new Date()

  const clientUser = { id: 0, createdAt, updatedAt } satisfies ClientUser

  const serverResponse = {
    data: {
      createdAt: createdAt.toISOString(),
      updatedAt: updatedAt.toISOString(),
    }
  }

  vi.test('codec satisfies the roundtrip property', () => {
    vi.assert.deepEqual(myCodec.decode(serverResponse), clientUser)
    vi.assert.deepEqual(myCodec.encode(myCodec.decode(serverResponse)), serverResponse)
    vi.assert.deepEqual(myCodec.decode(myCodec.encode(myCodec.decode(serverResponse))), clientUser)
  })
```