### PR TITLE
feat(schema): adds `t.array.shorterThan`, `t.array.longerThan`

### DIFF
--- a/.changeset/angry-queens-obey.md
+++ b/.changeset/angry-queens-obey.md
@@ -4,7 +4,7 @@
 "@traversable/schema": patch
 ---
 
-## new featuers
+## new features
 
 This PR adds the following new sub-combinators, all fuzz-tested & 100% covered:
   

--- a/.changeset/shiny-cloths-type.md
+++ b/.changeset/shiny-cloths-type.md
@@ -1,0 +1,26 @@
+---
+"@traversable/schema": patch
+---
+
+## changes
+
+This PR renames a few schema constraints to make the semantics more explicit / less ambiguous.
+
+This is not a breaking change, since the schema constraints API has not yet been published.
+
+1. renames `.btwn` to `.between`
+  - `t.integer.btwn` -> `t.integer.between`
+  - `t.bigint.btwn` -> `t.bigint.between`
+  - `t.number.btwn` -> `t.number.between`
+  - `t.string.btwn` -> `t.string.between`
+  - `t.array.btwn` -> `t.array.between`
+
+2. renames `.lt` to `.lessThan`
+  - `t.integer.lt` -> `t.integer.lessThan`
+  - `t.bigint.lt` -> `t.bigint.lessThan`
+  - `t.number.lt` -> `t.number.lessThan`
+
+3. renames `.gt` to `.moreThan`
+  - `t.integer.gt` -> `t.integer.moreThan`
+  - `t.bigint.gt` -> `t.bigint.moreThan`
+  - `t.number.gt` -> `t.number.moreThan`

--- a/.changeset/smart-deer-love.md
+++ b/.changeset/smart-deer-love.md
@@ -1,0 +1,10 @@
+---
+"@traversable/schema": patch
+---
+
+## new features
+
+This PR adds a few schema constraints that we missed:
+
+- `t.array.longerThan`
+- `t.array.shorterThan`

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "reboot": "./bin/reboot.ts",
     "test": "vitest run -- --skipTypes && tsc -b tsconfig.json",
     "test:cov": "pnpm vitest run --coverage",
-    "test:watch": "vitest watch",
+    "test:watch": "pnpm vitest --coverage",
+    "test:watch:no-cov": "pnpm vitest",
     "workspace:new": "./bin/workspace-create.ts",
     "workspace:rm": "./bin/workspace-cleanup.ts"
   },

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -228,33 +228,28 @@ interface integer extends Typeguard<number> {
   def: this['_type']
   min<T extends number>(minimum: T): integer.min<T>
   max<T extends number>(maximum: T): integer.max<T>
-  gt<T extends number>(moreThan: T): integer.moreThan<T>
-  lt<T extends number>(lessThan: T): integer.lessThan<T>
-  btwn<Min extends number, Max extends number>(minimum: Min, maximum: Max): integer.btwn<[min: Min, max: Max]>
+  moreThan<T extends number>(moreThan: T): integer.moreThan<T>
+  lessThan<T extends number>(lessThan: T): integer.lessThan<T>
+  between<Min extends number, Max extends number>(minimum: Min, maximum: Max): integer.between<[min: Min, max: Max]>
 }
 declare namespace integer {
-  interface min<Min extends number> extends Typeguard<number> { tag: URI.integer, def: this['_type'], min: Min }
-  interface max<Max extends number> extends Typeguard<number> { tag: URI.integer, def: this['_type'], max: Max }
+  interface min<Min extends number> extends Typeguard<number> { tag: URI.integer, def: this['_type'], gte: Min }
+  interface max<Max extends number> extends Typeguard<number> { tag: URI.integer, def: this['_type'], lte: Max }
   interface moreThan<Min extends number> extends Typeguard<number> { tag: URI.integer, def: this['_type'], gt: Min }
   interface lessThan<Max extends number> extends Typeguard<number> { tag: URI.integer, def: this['_type'], lt: Max }
-  interface btwn<Bounds extends [min: number, max: number]> extends Typeguard<number> {
-    tag: URI.integer
-    def: this['_type']
-    min: Bounds[0]
-    max: Bounds[1]
-  }
+  interface between<Bounds extends [min: number, max: number]> extends Typeguard<number> { tag: URI.integer, def: this['_type'], gte: Bounds[0], lte: Bounds[1] }
 }
 const integer = <integer>function IntegerSchema(src: unknown) { return Number_isSafeInteger(src) }
 integer.tag = URI.integer
 integer.def = 0
-integer.min = (min) => Object_assign(boundedInteger({ gte: min }), { min })
-integer.max = (max) => Object_assign(boundedInteger({ lte: max }), { max })
-integer.gt = (gt) => Object_assign(boundedInteger({ gt }), { gt })
-integer.lt = (lt) => Object_assign(boundedInteger({ lt }), { lt })
-integer.btwn = (min, max) => Object_assign(
-  boundedInteger({ gte: Math_min(min, max), lte: Math_max(min, max) }),
-  { min: Math_min(min, max) as never, max: Math_max(min, max) as never }
-)
+integer.min = (gte) => Object_assign(boundedInteger({ gte }), { gte })
+integer.max = (lte) => Object_assign(boundedInteger({ lte }), { lte })
+integer.moreThan = (gt) => Object_assign(boundedInteger({ gt }), { gt })
+integer.lessThan = (lt) => Object_assign(boundedInteger({ lt }), { lt })
+integer.between = (min, max) => {
+  const bounds = { gte: Math_min(min, max), lte: Math_max(min, max) }
+  return Object_assign(boundedInteger(bounds), bounds as never)
+}
 
 export { bigint_ as bigint }
 interface bigint_ extends Typeguard<bigint> {
@@ -262,33 +257,28 @@ interface bigint_ extends Typeguard<bigint> {
   def: this['_type']
   min<T extends bigint>(minimum: T): bigint_.min<T>
   max<T extends bigint>(maximum: T): bigint_.max<T>
-  gt<T extends bigint>(moreThan: T): bigint_.moreThan<T>
-  lt<T extends bigint>(lessThan: T): bigint_.lessThan<T>
-  btwn<Min extends bigint, Max extends bigint>(minimum: Min, maximum: Max): bigint_.btwn<[min: Min, max: Max]>
+  moreThan<T extends bigint>(moreThan: T): bigint_.moreThan<T>
+  lessThan<T extends bigint>(lessThan: T): bigint_.lessThan<T>
+  between<Min extends bigint, Max extends bigint>(minimum: Min, maximum: Max): bigint_.between<[min: Min, max: Max]>
 }
 declare namespace bigint_ {
-  interface min<Min extends bigint> extends Typeguard<bigint> { tag: URI.bigint, def: this['_type'], min: Min }
-  interface max<Max extends bigint> extends Typeguard<bigint> { tag: URI.bigint, def: this['_type'], max: Max }
+  interface min<Min extends bigint> extends Typeguard<bigint> { tag: URI.bigint, def: this['_type'], gte: Min }
+  interface max<Max extends bigint> extends Typeguard<bigint> { tag: URI.bigint, def: this['_type'], lte: Max }
   interface moreThan<Min extends bigint> extends Typeguard<bigint> { tag: URI.bigint, def: this['_type'], gt: Min }
   interface lessThan<Max extends bigint> extends Typeguard<bigint> { tag: URI.bigint, def: this['_type'], lt: Max }
-  interface btwn<Bounds extends [min: bigint, max: bigint]> extends Typeguard<bigint> {
-    tag: URI.bigint
-    def: this['_type']
-    min: Bounds[0]
-    max: Bounds[1]
-  }
+  interface between<Bounds extends [min: bigint, max: bigint]> extends Typeguard<bigint> { tag: URI.bigint, def: this['_type'], gte: Bounds[0], lte: Bounds[1] }
 }
 const bigint_ = <bigint_>function BigIntSchema(src: unknown) { return typeof src === 'bigint' }
 bigint_.tag = URI.bigint
 bigint_.def = 0n
-bigint_.min = (min) => Object_assign(boundedBigInt({ gte: min }), { min })
-bigint_.max = (max) => Object_assign(boundedBigInt({ lte: max }), { max })
-bigint_.gt = (gt) => Object_assign(boundedBigInt({ gt }), { gt })
-bigint_.lt = (lt) => Object_assign(boundedBigInt({ lt }), { lt })
-bigint_.btwn = (min, max) => Object_assign(
-  boundedBigInt({ gte: max < min ? max : min, lte: max < min ? min : max }),
-  { min: (max < min ? max : min) as never, max: (max < min ? min : max) as never }
-)
+bigint_.min = (gte) => Object_assign(boundedBigInt({ gte }), { gte })
+bigint_.max = (lte) => Object_assign(boundedBigInt({ lte }), { lte })
+bigint_.moreThan = (gt) => Object_assign(boundedBigInt({ gt }), { gt })
+bigint_.lessThan = (lt) => Object_assign(boundedBigInt({ lt }), { lt })
+bigint_.between = (min, max) => {
+  const bounds = { gte: max < min ? max : min, lte: max < min ? min : max }
+  return Object_assign(boundedBigInt(bounds), bounds as never)
+}
 
 export { number_ as number }
 interface number_ extends Typeguard<number> {
@@ -296,34 +286,28 @@ interface number_ extends Typeguard<number> {
   def: this['_type']
   min<T extends number>(minimum: T): number_.min<T>
   max<T extends number>(maximum: T): number_.max<T>
-  gt<T extends number>(moreThan: T): number_.moreThan<T>
-  lt<T extends number>(lessThan: T): number_.lessThan<T>
-  btwn<Min extends number, Max extends number>(minimum: Min, maximum: Max): number_.btwn<[min: Min, max: Max]>
+  moreThan<T extends number>(moreThan: T): number_.moreThan<T>
+  lessThan<T extends number>(lessThan: T): number_.lessThan<T>
+  between<Min extends number, Max extends number>(minimum: Min, maximum: Max): number_.between<[min: Min, max: Max]>
 }
 declare namespace number_ {
-  interface min<Min extends number> extends Typeguard<number> { tag: URI.number, def: this['_type'], min: Min }
-  interface max<Max extends number> extends Typeguard<number> { tag: URI.number, def: this['_type'], max: Max }
+  interface min<Min extends number> extends Typeguard<number> { tag: URI.number, def: this['_type'], gte: Min }
+  interface max<Max extends number> extends Typeguard<number> { tag: URI.number, def: this['_type'], lte: Max }
   interface moreThan<Min extends number> extends Typeguard<number> { tag: URI.number, def: this['_type'], gt: Min }
   interface lessThan<Max extends number> extends Typeguard<number> { tag: URI.number, def: this['_type'], lt: Max }
-  interface btwn<Bounds extends [min: number, max: number]> extends Typeguard<number> {
-    tag: URI.number
-    def: this['_type']
-    min: Bounds[0]
-    max: Bounds[1]
-  }
+  interface between<Bounds extends [min: number, max: number]> extends Typeguard<number> { tag: URI.number, def: this['_type'], gte: Bounds[0], lte: Bounds[1] }
 }
 const number_ = <number_>function NumberSchema(src: unknown) { return typeof src === 'number' }
 number_.tag = URI.number
 number_.def = 0
-number_.min = (min) => Object_assign(boundedNumber({ gte: min }), { min })
-number_.max = (max) => Object_assign(boundedNumber({ lte: max }), { max })
-number_.gt = (gt) => Object_assign(boundedNumber({ gt }), { gt })
-number_.lt = (lt) => Object_assign(boundedNumber({ lt }), { lt })
-number_.btwn = (min, max) => Object_assign(
-  boundedNumber({ gte: Math_min(min, max), lte: Math_max(min, max) }),
-  { min: Math_min(min, max) as never, max: Math_max(min, max) as never }
-)
-
+number_.min = (gte) => Object_assign(boundedNumber({ gte }), { gte })
+number_.max = (lte) => Object_assign(boundedNumber({ lte }), { lte })
+number_.moreThan = (gt) => Object_assign(boundedNumber({ gt }), { gt })
+number_.lessThan = (lt) => Object_assign(boundedNumber({ lt }), { lt })
+number_.between = (min, max) => {
+  const bounds = { gte: Math_min(min, max), lte: Math_max(min, max) }
+  return Object_assign(boundedNumber(bounds), bounds as never)
+}
 
 export { string_ as string }
 interface string_ extends Typeguard<string> {
@@ -333,31 +317,31 @@ interface string_ extends Typeguard<string> {
   max<T extends number>(maxLength: T): string_.max<T>
   shorterThan<T extends number>(shorterThan: T): string_.shorterThan<T>
   longerThan<T extends number>(longerThan: T): string_.longerThan<T>
-  btwn<Min extends number, Max extends number>(minLength: Min, maxLength: Max): string_.btwn<[min: Min, max: Max]>
+  between<Min extends number, Max extends number>(minLength: Min, maxLength: Max): string_.between<[min: Min, max: Max]>
 }
 declare namespace string_ {
-  interface min<Min extends number> extends Typeguard<string> { tag: URI.string, def: this['_type'], min: Min }
-  interface max<Max extends number> extends Typeguard<string> { tag: URI.string, def: this['_type'], max: Max }
+  interface min<Min extends number> extends Typeguard<string> { tag: URI.string, def: this['_type'], gte: Min }
+  interface max<Max extends number> extends Typeguard<string> { tag: URI.string, def: this['_type'], lte: Max }
   interface longerThan<Min extends number> extends Typeguard<string> { tag: URI.string, def: this['_type'], gt: Min }
   interface shorterThan<Max extends number> extends Typeguard<string> { tag: URI.string, def: this['_type'], lt: Max }
-  interface btwn<Bounds extends [min: number, max: number]> extends Typeguard<string> {
+  interface between<Bounds extends [min: number, max: number]> extends Typeguard<string> {
     tag: URI.string
     def: this['_type']
-    min: Bounds[0]
-    max: Bounds[1]
+    gte: Bounds[0]
+    lte: Bounds[1]
   }
 }
 const string_ = <string_>function StringSchema(src: unknown) { return typeof src === 'string' }
 string_.tag = URI.string
 string_.def = ''
-string_.min = (min) => Object_assign(boundedString({ gte: min }), { min })
-string_.max = (max) => Object_assign(boundedString({ lte: max }), { max })
+string_.min = (gte) => Object_assign(boundedString({ gte }), { gte })
+string_.max = (lte) => Object_assign(boundedString({ lte }), { lte })
 string_.shorterThan = (lt) => Object_assign(boundedString({ lt }), { lt })
 string_.longerThan = (gt) => Object_assign(boundedString({ gt }), { gt })
-string_.btwn = (min, max) => Object_assign(
-  boundedString({ gte: Math_min(min, max), lte: Math_max(min, max) }),
-  { min: Math_min(min, max) as never, max: Math_max(min, max) as never }
-)
+string_.between = (min, max) => {
+  const bounds = { gte: Math_min(min, max), lte: Math_max(min, max) }
+  return Object_assign(boundedString(bounds), bounds as never)
+}
 
 export { nonnullable }
 interface nonnullable extends Typeguard<{}> { tag: URI.nonnullable, def: this['_type'] }
@@ -417,31 +401,39 @@ export interface array<S> {
   _type: S['_type' & keyof S][]
   min<Min extends number>(minLength: Min): array.min<Min, S>
   max<Max extends number>(maxLength: Max): array.max<Max, S>
-  btwn<Min extends number, Max extends number>(minLength: Min, maxLength: Max): array.btwn<[min: Min, max: Max], S>
+  longerThan<Min extends number>(longerThan: Min): array.longerThan<Min, S>
+  shorterThan<Max extends number>(shorterThan: Max): array.shorterThan<Max, S>
+  between<Min extends number, Max extends number>(minLength: Min, maxLength: Max): array.between<[min: Min, max: Max], S>
 }
 export namespace array {
   export type type<S, T = S['_type' & keyof S][]> = never | T
   export function def<S>(x: S): array<S>
   export function def<S>(x: S): {} {
     const arrayGuard = isPredicate(x) ? guard.array(x) : guard.anyArray
-    const arrayMin: array<S>['min'] = (minLength) => Object_assign(boundedArray(x, { gte: minLength }), { min: minLength })
-    const arrayMax: array<S>['max'] = (maxLength) => Object_assign(boundedArray(x, { lte: maxLength }), { max: maxLength })
-    const arrayBtwn: array<S>['btwn'] = (min, max) => Object_assign(
-      boundedArray(x, { gte: Math_min(min, max), lte: Math_max(max, min) }),
-      { min: Math_min(min, max) as never, max: Math_max(min, max) as never }
-    )
+    const arrayMin: array<S>['min'] = (gte) => Object_assign(boundedArray(x, { gte }), { gte })
+    const arrayMax: array<S>['max'] = (lte) => Object_assign(boundedArray(x, { lte }), { lte })
+    const arrayLongerThan: array<S>['longerThan'] = (gt) => Object_assign(boundedArray(x, { gt }), { gt })
+    const arrayShorterThan: array<S>['shorterThan'] = (lt) => Object_assign(boundedArray(x, { lt }), { lt })
+    const arrayBetween: array<S>['between'] = (min, max) => {
+      const bounds = { gte: Math_min(min, max), lte: Math_max(max, min) }
+      return Object_assign(boundedArray(x, bounds), bounds as never)
+    }
     function ArraySchema(src: unknown): src is array<S>['_type'] { return arrayGuard(src) }
     ArraySchema.tag = URI.array
     ArraySchema.def = x
     ArraySchema.min = arrayMin
     ArraySchema.max = arrayMax
-    ArraySchema.btwn = arrayBtwn
+    ArraySchema.longerThan = arrayLongerThan
+    ArraySchema.shorterThan = arrayShorterThan
+    ArraySchema.between = arrayBetween
     ArraySchema._type = void 0 as never
     return ArraySchema
   }
-  export interface min<Min extends number, S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, min: Min }
-  export interface max<Max extends number, S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, max: Max }
-  export interface btwn<Bounds extends [min: number, max: number], S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, min: Bounds[0], max: Bounds[1] }
+  export interface min<Min extends number, S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, gte: Min }
+  export interface max<Max extends number, S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, lte: Max }
+  export interface longerThan<Min extends number, S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, gt: Min }
+  export interface shorterThan<Max extends number, S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, lt: Max }
+  export interface between<Bounds extends [min: number, max: number], S> { tag: URI.array, (u: unknown): u is this['_type'], _type: S['_type' & keyof S][], def: S, gte: Bounds[0], lte: Bounds[1] }
 }
 
 export const readonlyArray: {

--- a/packages/schema/test/bounded.test.ts
+++ b/packages/schema/test/bounded.test.ts
@@ -4,37 +4,54 @@ import { fc, test } from '@fast-check/vitest'
 
 vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
   vi.it('〖⛳️〗‹ ❲within❳', () => {
+    // SUCCESS
     vi.assert.isTrue(within({ gt: 0 })(1))
-    vi.assert.isTrue(within({ gt: 0, lt: 1 })(0.5))
-    vi.assert.isTrue(within({ lt: 1 })(0.5))
+    vi.assert.isTrue(within({ gt: 0, lt: 2 })(1))
+    vi.assert.isTrue(within({ lt: 2 })(1))
+    // FAILURE
+    vi.assert.isFalse(within({ gt: 0 })(0))
+    vi.assert.isFalse(within({ gt: 0, lt: 0 })(0))
+    vi.assert.isFalse(within({ lt: 0 })(0))
     /* @ts-expect-error */
     vi.assert.throws(() => within({ gt: '' })(0.5))
   })
 
   vi.it('〖⛳️〗‹ ❲withinBig❳', () => {
+    // SUCCESS
     vi.assert.isTrue(withinBig({})(1))
-    vi.assert.isTrue(withinBig({ lte: 0 })(0))
-    vi.assert.isTrue(withinBig({ gte: 0 })(0))
-    vi.assert.isTrue(withinBig({ lt: 0 })(-1))
-    vi.assert.isTrue(withinBig({ gt: 0 })(+1))
+    vi.assert.isTrue(withinBig({ lte: 1 })(1))
+    vi.assert.isTrue(withinBig({ gte: 1 })(1))
+    vi.assert.isTrue(withinBig({ lt: 2 })(1))
+    vi.assert.isTrue(withinBig({ gt: 0 })(1))
     vi.assert.isTrue(withinBig({ gt: 0, lt: 2 })(1))
     vi.assert.isTrue(withinBig({ gt: 0, lte: 1 })(1))
     vi.assert.isTrue(withinBig({ gte: 0, lt: 2 })(1))
     vi.assert.isTrue(withinBig({ gte: 0, lte: 1 })(1))
-
     vi.assert.isTrue(withinBig({ gt: 0, lt: 2, gte: 1 })(1))
     vi.assert.isTrue(withinBig({ gt: 0, lte: 1, gte: 1 })(1))
     vi.assert.isTrue(withinBig({ gte: 1, lt: 2, lte: 1 })(1))
     vi.assert.isTrue(withinBig({ gte: 1, lte: 1, lt: 2 })(1))
     vi.assert.isTrue(withinBig({ gte: 1, lte: 1, gt: 0 })(1))
     vi.assert.isTrue(withinBig({ gte: 1, lt: 2, gt: 0 })(1))
-
     vi.assert.isTrue(withinBig({ gte: 1, lte: 1, lt: 2, gt: 0 })(1))
-
-    vi.assert.isTrue(withinBig({ lt: 1 })(0.5))
+    // FAILURE
+    vi.assert.isFalse(withinBig({ lte: 0 })(1))
+    vi.assert.isFalse(withinBig({ gte: 1 })(-1))
+    vi.assert.isFalse(withinBig({ lt: 0 })(1))
+    vi.assert.isFalse(withinBig({ gt: 2 })(-1))
+    vi.assert.isFalse(withinBig({ gt: 0, lt: 2 })(-1))
+    vi.assert.isFalse(withinBig({ gt: 0, lte: 1 })(-1))
+    vi.assert.isFalse(withinBig({ gte: 0, lt: 2 })(-1))
+    vi.assert.isFalse(withinBig({ gte: 0, lte: 1 })(-1))
+    vi.assert.isFalse(withinBig({ gt: 0, lt: 2, gte: 1 })(-1))
+    vi.assert.isFalse(withinBig({ gt: 0, lte: 1, gte: 1 })(-1))
+    vi.assert.isFalse(withinBig({ gte: 1, lt: 2, lte: 1 })(-1))
+    vi.assert.isFalse(withinBig({ gte: 1, lte: 1, lt: 2 })(-1))
+    vi.assert.isFalse(withinBig({ gte: 1, lte: 1, gt: 0 })(-1))
+    vi.assert.isFalse(withinBig({ gte: 1, lt: 2, gt: 0 })(-1))
+    vi.assert.isFalse(withinBig({ gte: 1, lte: 1, lt: 2, gt: 0 })(-1))
     /* @ts-expect-error */
     vi.assert.throws(() => withinBig({ gt: '' })(0.5))
-
   })
 
   vi.describe('〖⛳️〗‹‹ ❲t.integer❳', () => {
@@ -44,7 +61,7 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.min❳: property test',
       (x, y, _) => {
         let schema = t.integer.min(x)
-        vi.assert.equal(schema(y), schema.min <= y)
+        vi.assert.equal(schema(y), schema.gte <= y)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -52,31 +69,31 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.max❳: property test',
       (x, y, _) => {
         let schema = t.integer.max(x)
-        vi.assert.equal(schema(y), y <= schema.max)
+        vi.assert.equal(schema(y), y <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([integer, integer, anything])(
-      '〖⛳️〗‹ ❲.gt❳: property test',
+      '〖⛳️〗‹ ❲.moreThan❳: property test',
       (x, y, _) => {
-        let schema = t.integer.gt(x)
+        let schema = t.integer.moreThan(x)
         vi.assert.equal(schema(y), schema.gt < y)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([integer, integer, anything])(
-      '〖⛳️〗‹ ❲.lt❳: property test',
+      '〖⛳️〗‹ ❲.lessThan❳: property test',
       (x, y, _) => {
-        let schema = t.integer.lt(x)
+        let schema = t.integer.lessThan(x)
         vi.assert.equal(schema(y), y < schema.lt)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([integer, integer, integer, anything])(
-      '〖⛳️〗‹ ❲.btwn❳: property test',
+      '〖⛳️〗‹ ❲.between❳: property test',
       (x, y, z, _) => {
-        let schema = t.integer.btwn(x, y)
-        vi.assert.equal(schema(z), schema.min <= z && z <= schema.max)
+        let schema = t.integer.between(x, y)
+        vi.assert.equal(schema(z), schema.gte <= z && z <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -94,7 +111,7 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.min❳: property test',
       (x, y, _) => {
         let schema = t.number.min(x)
-        vi.assert.equal(schema(y), schema.min <= y)
+        vi.assert.equal(schema(y), schema.gte <= y)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -102,31 +119,31 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.max❳: property test',
       (x, y, _) => {
         let schema = t.number.max(x)
-        vi.assert.equal(schema(y), y <= schema.max)
+        vi.assert.equal(schema(y), y <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([number, number, anything])(
-      '〖⛳️〗‹ ❲.gt❳: property test',
+      '〖⛳️〗‹ ❲.moreThan❳: property test',
       (x, y, _) => {
-        let schema = t.number.gt(x)
+        let schema = t.number.moreThan(x)
         vi.assert.equal(schema(y), schema.gt < y)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([number, number, anything])(
-      '〖⛳️〗‹ ❲.lt❳: property test',
+      '〖⛳️〗‹ ❲.lessThan❳: property test',
       (x, y, _) => {
-        let schema = t.number.lt(x)
+        let schema = t.number.lessThan(x)
         vi.assert.equal(schema(y), y < schema.lt)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([number, number, number, anything])(
-      '〖⛳️〗‹ ❲.btwn❳: property test',
+      '〖⛳️〗‹ ❲.between❳: property test',
       (x, y, z, _) => {
-        let schema = t.number.btwn(x, y)
-        vi.assert.equal(schema(z), schema.min <= z && z <= schema.max)
+        let schema = t.number.between(x, y)
+        vi.assert.equal(schema(z), schema.gte <= z && z <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -139,7 +156,7 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.min❳: property test',
       (x, y, _) => {
         let schema = t.bigint.min(x)
-        vi.assert.equal(schema(y), schema.min <= y)
+        vi.assert.equal(schema(y), schema.gte <= y)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -147,31 +164,31 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.max❳: property test',
       (x, y, _) => {
         let schema = t.bigint.max(x)
-        vi.assert.equal(schema(y), y <= schema.max)
+        vi.assert.equal(schema(y), y <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([bigint, bigint, anything])(
-      '〖⛳️〗‹ ❲.gt❳: property test',
+      '〖⛳️〗‹ ❲.moreThan❳: property test',
       (x, y, _) => {
-        let schema = t.bigint.gt(x)
+        let schema = t.bigint.moreThan(x)
         vi.assert.equal(schema(y), schema.gt < y)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([bigint, bigint, anything])(
-      '〖⛳️〗‹ ❲.lt❳: property test',
+      '〖⛳️〗‹ ❲.lessThan❳: property test',
       (x, y, _) => {
-        let schema = t.bigint.lt(x)
+        let schema = t.bigint.lessThan(x)
         vi.assert.equal(schema(y), y < schema.lt)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([bigint, bigint, bigint, anything])(
-      '〖⛳️〗‹ ❲.btwn❳: property test',
+      '〖⛳️〗‹ ❲.between❳: property test',
       (x, y, z, _) => {
-        let schema = t.bigint.btwn(x, y)
-        vi.assert.equal(schema(z), schema.min <= z && z <= schema.max)
+        let schema = t.bigint.between(x, y)
+        vi.assert.equal(schema(z), schema.gte <= z && z <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -180,12 +197,13 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
   vi.describe('〖⛳️〗‹‹ ❲t.string❳', () => {
     const anything = fc.anything().filter((_) => typeof _ !== 'string')
     const string = fc.string()
-    const integer = fc.integer()
+    const integer = fc.nat()
+    const oneOrMore = fc.integer({ min: 1 })
     test.prop([integer, string, anything])(
       '〖⛳️〗‹ ❲.min❳: property test',
       (x, s, _) => {
         let schema = t.string.min(x)
-        vi.assert.equal(schema(s), schema.min <= s.length)
+        vi.assert.equal(schema(s), schema.gte <= s.length)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -193,15 +211,31 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.max❳: property test',
       (x, s, _) => {
         let schema = t.string.max(x)
-        vi.assert.equal(schema(s), s.length <= schema.max)
+        vi.assert.equal(schema(s), s.length <= schema.lte)
+        vi.assert.isFalse(schema(_))
+      }
+    )
+    test.prop([integer, string, anything])(
+      '〖⛳️〗‹ ❲.longerThan❳: property test',
+      (x, s, _) => {
+        let schema = t.string.longerThan(x)
+        vi.assert.equal(schema(s), schema.gt < s.length)
+        vi.assert.isFalse(schema(_))
+      }
+    )
+    test.prop([oneOrMore, string, anything])(
+      '〖⛳️〗‹ ❲.shorterThan❳: property test',
+      (x, s, _) => {
+        let schema = t.string.shorterThan(x)
+        vi.assert.equal(schema(s), s.length < schema.lt)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([integer, integer, string, anything])(
-      '〖⛳️〗‹ ❲.btwn❳: property test',
+      '〖⛳️〗‹ ❲.between❳: property test',
       (x, y, s, _) => {
-        let schema = t.string.btwn(x, y)
-        vi.assert.equal(schema(s), schema.min <= s.length && s.length <= schema.max)
+        let schema = t.string.between(x, y)
+        vi.assert.equal(schema(s), schema.gte <= s.length && s.length <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -210,12 +244,13 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
   vi.describe('〖⛳️〗‹‹ ❲t.array❳', () => {
     const anything = fc.anything().filter((_) => !Array.isArray(_))
     const array = fc.array(fc.anything())
-    const integer = fc.integer()
+    const integer = fc.nat()
+    const oneOrMore = fc.integer({ min: 1 })
     test.prop([integer, array, anything])(
       '〖⛳️〗‹ ❲.min❳: property test',
       (x, xs, _) => {
         let schema = t.array(t.any).min(x)
-        vi.assert.equal(schema(xs), schema.min <= xs.length)
+        vi.assert.equal(schema(xs), schema.gte <= xs.length)
         vi.assert.isFalse(schema(_))
       }
     )
@@ -223,15 +258,31 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traverable/schema/bounded❳', () => {
       '〖⛳️〗‹ ❲.max❳: property test',
       (x, xs, _) => {
         let schema = t.array(t.any).max(x)
-        vi.assert.equal(schema(xs), xs.length <= schema.max)
+        vi.assert.equal(schema(xs), xs.length <= schema.lte)
+        vi.assert.isFalse(schema(_))
+      }
+    )
+    test.prop([integer, array, anything])(
+      '〖⛳️〗‹ ❲.longerThan❳: property test',
+      (x, xs, _) => {
+        let schema = t.array(t.any).longerThan(x)
+        vi.assert.equal(schema(xs), schema.gt < xs.length)
+        vi.assert.isFalse(schema(_))
+      }
+    )
+    test.prop([oneOrMore, array, anything])(
+      '〖⛳️〗‹ ❲.shorterThan❳: property test',
+      (x, xs, _) => {
+        let schema = t.array(t.any).shorterThan(x)
+        vi.assert.equal(schema(xs), xs.length < schema.lt)
         vi.assert.isFalse(schema(_))
       }
     )
     test.prop([integer, integer, array, anything])(
-      '〖⛳️〗‹ ❲.btwn❳: property test',
+      '〖⛳️〗‹ ❲.between❳: property test',
       (x, y, xs, _) => {
-        let schema = t.array(t.any).btwn(x, y)
-        vi.assert.equal(schema(xs), schema.min <= xs.length && xs.length <= schema.max)
+        let schema = t.array(t.any).between(x, y)
+        vi.assert.equal(schema(xs), schema.gte <= xs.length && xs.length <= schema.lte)
         vi.assert.isFalse(schema(_))
       }
     )


### PR DESCRIPTION
Closes #160 
Closes #161 

## new features

This PR adds a few schema constraints that we missed:

- `t.array.longerThan`
- `t.array.shorterThan`


## changes

This PR renames a few schema constraints to make the semantics more explicit / less ambiguous.

Note that this is not a breaking change, since the schema constraints API has not yet been published.

1. renames `.btwn` to `.between`
  - `t.integer.btwn` -> `t.integer.between`
  - `t.bigint.btwn` -> `t.bigint.between`
  - `t.number.btwn` -> `t.number.between`
  - `t.string.btwn` -> `t.string.between`
  - `t.array.btwn` -> `t.array.between`

2. renames `.lt` to `.lessThan`
  - `t.integer.lt` -> `t.integer.lessThan`
  - `t.bigint.lt` -> `t.bigint.lessThan`
  - `t.number.lt` -> `t.number.lessThan`

3. renames `.gt` to `.moreThan`
  - `t.integer.gt` -> `t.integer.moreThan`
  - `t.bigint.gt` -> `t.bigint.moreThan`
  - `t.number.gt` -> `t.number.moreThan`