### PR TITLE
prevent(*): CVE 2025 57820

### DIFF
--- a/.changeset/fancy-lands-marry.md
+++ b/.changeset/fancy-lands-marry.md
@@ -1,0 +1,30 @@
+---
+"@traversable/arktype": patch
+"@traversable/arktype-test": patch
+"@traversable/arktype-types": patch
+"@traversable/json": patch
+"@traversable/json-schema": patch
+"@traversable/json-schema-test": patch
+"@traversable/json-schema-types": patch
+"@traversable/registry": patch
+"@traversable/schema": patch
+"@traversable/schema-codec": patch
+"@traversable/schema-compiler": patch
+"@traversable/schema-deep-equal": patch
+"@traversable/schema-errors": patch
+"@traversable/schema-seed": patch
+"@traversable/schema-to-json-schema": patch
+"@traversable/schema-to-string": patch
+"@traversable/schema-to-validator": patch
+"@traversable/typebox": patch
+"@traversable/typebox-test": patch
+"@traversable/typebox-types": patch
+"@traversable/valibot": patch
+"@traversable/valibot-test": patch
+"@traversable/valibot-types": patch
+"@traversable/zod": patch
+"@traversable/zod-test": patch
+"@traversable/zod-types": patch
+---
+
+CVE-2025-57820

--- a/.changeset/fancy-lands-marry.md
+++ b/.changeset/fancy-lands-marry.md
@@ -27,4 +27,4 @@
 "@traversable/zod-types": patch
 ---
 
-CVE-2025-57820
+prevent(*): CVE 2025 57820

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -13,7 +13,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tanstack/react-form": "^1.1.2",
     "@traversable/schema-to-validator": "workspace:^",
     "@traversable/json": "workspace:^",
     "@traversable/registry": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
 
   examples/sandbox:
     dependencies:
-      '@tanstack/react-form':
-        specifier: ^1.1.2
-        version: 1.19.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@traversable/json':
         specifier: workspace:^
         version: link:../../packages/json/dist
@@ -1502,27 +1499,6 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
-  '@tanstack/form-core@1.19.2':
-    resolution: {integrity: sha512-g2VkZCHEQUxnPOtF+vNHQDGvmrXfMpvN1T27M+G2R/eeH2vImxEdzVzAVIR71DZ5X3QtC9rm+nR64MJrjI+yXQ==}
-
-  '@tanstack/react-form@1.19.2':
-    resolution: {integrity: sha512-pfhyPXxuiq6U/GUaQQf6m8TdKUdmrygJkqY3A6R/0tiQFL/B/HsOeovPGxpwAdDof2V6hJd5+/XbDz0B76iVIQ==}
-    peerDependencies:
-      '@tanstack/react-start': ^1.130.10
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@tanstack/react-start':
-        optional: true
-
-  '@tanstack/react-store@0.7.4':
-    resolution: {integrity: sha512-DyG1e5Qz/c1cNLt/NdFbCA7K1QGuFXQYT6EfUltYMJoQ4LzBOGnOl5IjuxepNcRtmIKkGpmdMzdFZEkevgU9bQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@tanstack/store@0.7.4':
-    resolution: {integrity: sha512-F1XqZQici1Aq6WigEfcxJSml92nW+85Om8ElBMokPNg5glCYVOmPkZGIQeieYFxcPiKTfwo0MTOQpUyJtwncrg==}
-
   '@ts-graphviz/adapter@2.0.6':
     resolution: {integrity: sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q==}
     engines: {node: '>=18'}
@@ -1966,9 +1942,6 @@ packages:
       supports-color:
         optional: true
 
-  decode-formdata@0.9.0:
-    resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
-
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2051,9 +2024,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       typescript: ^5.4.4
-
-  devalue@5.1.1:
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3396,11 +3366,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  use-sync-external-store@1.5.0:
-    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4370,29 +4335,6 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
-  '@tanstack/form-core@1.19.2':
-    dependencies:
-      '@tanstack/store': 0.7.4
-
-  '@tanstack/react-form@1.19.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@tanstack/form-core': 1.19.2
-      '@tanstack/react-store': 0.7.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      decode-formdata: 0.9.0
-      devalue: 5.1.1
-      react: 19.1.1
-    transitivePeerDependencies:
-      - react-dom
-
-  '@tanstack/react-store@0.7.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@tanstack/store': 0.7.4
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      use-sync-external-store: 1.5.0(react@19.1.1)
-
-  '@tanstack/store@0.7.4': {}
-
   '@ts-graphviz/adapter@2.0.6':
     dependencies:
       '@ts-graphviz/common': 2.1.5
@@ -4931,8 +4873,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decode-formdata@0.9.0: {}
-
   deep-eql@5.0.2: {}
 
   deep-equal@2.2.3:
@@ -5044,8 +4984,6 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
-
-  devalue@5.1.1: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -6386,10 +6324,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-sync-external-store@1.5.0(react@19.1.1):
-    dependencies:
-      react: 19.1.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
This CVE does not affect any of the `@traversable/*` libraries themselves, but rather the sandbox, which had a transitive dependency on `devalue@5.1.1` via `@tanstack/react-form@1.1.2`

Vulnerability: https://github.com/advisories/GHSA-vj54-72f3-p5jv
Weakness: https://cwe.mitre.org/data/definitions/1321.html
Alert: https://github.com/traversable/schema/security/dependabot/14