### PR TITLE
fix(json-schema): wraps unions and intersections in parens when generating types

### DIFF
--- a/.changeset/fast-points-hang.md
+++ b/.changeset/fast-points-hang.md
@@ -1,0 +1,6 @@
+---
+"@traversable/json-schema-types": patch
+"@traversable/json-schema": patch
+---
+
+fix(json-schema,json-schema-types): fixes `JsonSchema.toType` precedence bug with unions

--- a/.changeset/small-towns-march.md
+++ b/.changeset/small-towns-march.md
@@ -1,0 +1,6 @@
+---
+"@traversable/valibot-types": patch
+"@traversable/valibot": patch
+---
+
+refactor(valibot,valibot-types): renames `vx.isOptionalDeep` to `vx.hasOptional`

--- a/.changeset/smooth-pandas-switch.md
+++ b/.changeset/smooth-pandas-switch.md
@@ -1,0 +1,6 @@
+---
+"@traversable/zod-types": patch
+"@traversable/zod": patch
+---
+
+refactor(zod,zod-types): renames `isOptionalDeep` to `hasOptional` and `isDefaultDeep` to `hasDefault`

--- a/packages/json-schema-types/src/check.ts
+++ b/packages/json-schema-types/src/check.ts
@@ -20,7 +20,7 @@ import { Json } from '@traversable/json'
 import * as F from './functor.js'
 import { toType } from './to-type.js'
 import * as JsonSchema from './types.js'
-type JsonSchema<T = unknown> = import('./types.js').JsonSchema<T>
+type JsonSchema<T = unknown> = import('./types.js').F<T>
 
 export const checkJson = Json.fold<(x: unknown) => boolean>((x) => {
   switch (true) {
@@ -416,7 +416,7 @@ function compileJson(x: Json, varName: string) {
   })(x as never, varName)
 }
 
-const compile = F.compile<string>((x, ix, input) => {
+const compile = F.compile<string>((x, ix) => {
   const VAR = ix.varName
   switch (true) {
     default: return x satisfies never

--- a/packages/json-schema-types/src/index.ts
+++ b/packages/json-schema-types/src/index.ts
@@ -1,3 +1,7 @@
 export * from './exports.js'
-export type JsonSchema<T = never> = import('./types.js').JsonSchema<T>
+
+export type JsonSchema<T = never> = [T] extends [never]
+  ? import('./types.js').JsonSchema
+  : import('./types.js').F<T>
+
 export * as JsonSchema from './exports.js'

--- a/packages/json-schema-types/src/types.ts
+++ b/packages/json-schema-types/src/types.ts
@@ -15,9 +15,6 @@ import { Array_isArray, has, isShowable } from '@traversable/registry'
  * See also:
  * - the [spec](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00)
  */
-export type JsonSchema<T = never> = [T] extends [never]
-  ? Fixpoint
-  : F<T>
 
 /** ## {@link Never `JsonSchema.Never`} */
 export type Never =
@@ -171,15 +168,15 @@ export type Unary<T> =
   | Union<T>
   | Intersection<T>
 
-export type Fixpoint =
+export type JsonSchema =
   | Nullary
   | Unknown
-  | Array<Fixpoint>
-  | Tuple<Fixpoint>
-  | Object<Fixpoint>
-  | Record<Fixpoint>
-  | Union<Fixpoint>
-  | Intersection<Fixpoint>
+  | Array<JsonSchema>
+  | Tuple<JsonSchema>
+  | Object<JsonSchema>
+  | Record<JsonSchema>
+  | Union<JsonSchema>
+  | Intersection<JsonSchema>
 
 export type F<T> =
   | Nullary
@@ -190,8 +187,6 @@ export type F<T> =
   | Record<T>
   | Union<T>
   | Intersection<T>
-
-// | Unary<T>
 
 export interface Free extends HKT { [-1]: F<this[0]> }
 

--- a/packages/json-schema-types/src/utils.ts
+++ b/packages/json-schema-types/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Target } from '@traversable/registry'
 import { intersectKeys } from '@traversable/registry'
 import * as JsonSchema from './types.js'
-type JsonSchema<T = unknown> = import('./types.js').JsonSchema<T>
+type JsonSchema<T = unknown> = import('./types.js').F<T>
 
 export type Tagged = {
   shape: Record<string, unknown>

--- a/packages/json-schema/src/deep-clone.ts
+++ b/packages/json-schema/src/deep-clone.ts
@@ -75,10 +75,10 @@ function getPredicates(unions: IndexedSchema[], stripTypes: boolean) {
     .map(({ index, ...x }) => check.writeable(x, { stripTypes, functionName: `check_${index}`, }))
 }
 
-function extractUnions(schema: JsonSchema<JsonSchema.Fixpoint>): ExtractedUnions {
+function extractUnions(schema: JsonSchema<JsonSchema>): ExtractedUnions {
   let index = 0
   let unions = Array.of<IndexedSchema>()
-  const out = F.fold<JsonSchema.Fixpoint>((x) => {
+  const out = F.fold<JsonSchema>((x) => {
     if (!JsonSchema.isUnion(x)) {
       return x
     } else if (getTags(x.anyOf) !== null) {

--- a/packages/json-schema/test/deep-clone.test.ts
+++ b/packages/json-schema/test/deep-clone.test.ts
@@ -1947,10 +1947,8 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traversable/zod❳: JsonSchema.deepClone.
     )).toMatchInlineSnapshot
       (`
       "type Type =
-        | { abc: string }
-        | { def: string }
-        | { ghi: string }
-        | { jkl: string }
+        | ({ abc: string } | { def: string })
+        | ({ ghi: string } | { jkl: string })
       function deepClone(prev: Type) {
         function check_0(value: any): value is { abc: string } {
           return !!value && typeof value === "object" && typeof value.abc === "string"

--- a/packages/valibot-types/src/utils.ts
+++ b/packages/valibot-types/src/utils.ts
@@ -120,7 +120,7 @@ export function isAnyTuple(x: unknown) {
     || tagged('tupleWithRest', x)
 }
 
-export function isOptionalDeep(x: unknown): boolean {
+export function hasOptional(x: unknown): boolean {
   switch (true) {
     default: return false
     case tagged('optional', x): return true

--- a/packages/valibot/src/to-type.ts
+++ b/packages/valibot/src/to-type.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot'
 import { Array_isArray, escape, escapeJsDoc, has, parseKey } from '@traversable/registry'
-import { hasType, tagged, F, isOptionalDeep, Invariant } from '@traversable/valibot-types'
+import { hasType, tagged, F, hasOptional, Invariant } from '@traversable/valibot-types'
 
 export type WithOptionalTypeName = {
   /**
@@ -188,7 +188,7 @@ const fold = F.fold<string>((x, ix, input) => {
           const READONLY_OPEN = isReadonly(original) ? 'Readonly<' : ''
           const READONLY_CLOSE = isReadonly(original) ? '>' : ''
           const REST = 'rest' in option && typeof option.rest === 'string' ? `{ [x: string]: ${option.rest} }` : ''
-          const OPT = Object.entries(original.entries).filter(([, v]) => isOptionalDeep(v)).map(([k]) => k)
+          const OPT = Object.entries(original.entries).filter(([, v]) => hasOptional(v)).map(([k]) => k)
           const xs = Object.entries(option.entries).map(
             ([k, v]) => {
               const description = getDescription(original[k])
@@ -240,7 +240,7 @@ const fold = F.fold<string>((x, ix, input) => {
       if (!tagged(x.type as 'object', input)) {
         return Invariant.IllegalState('toType', `Expected input to be a${x.type === 'object' ? 'n' : ''} ${x.type} schema`, input)
       } else {
-        const OPT = Object.entries(input.entries).filter(([, v]) => isOptionalDeep(v)).map(([k]) => k)
+        const OPT = Object.entries(input.entries).filter(([, v]) => hasOptional(v)).map(([k]) => k)
         const READONLY_OPEN = isReadonly(input) ? 'Readonly<' : ''
         const READONLY_CLOSE = isReadonly(input) ? '>' : ''
         const xs = Object.entries(x.entries).map(
@@ -267,7 +267,7 @@ const fold = F.fold<string>((x, ix, input) => {
       if (!tagged('objectWithRest', input)) {
         return Invariant.IllegalState('toType', 'Expected input to be an object with rest schema', input)
       } else {
-        const OPT = Object.entries(input.entries).filter(([, v]) => isOptionalDeep(v)).map(([k]) => k)
+        const OPT = Object.entries(input.entries).filter(([, v]) => hasOptional(v)).map(([k]) => k)
         const REST = ` & { [x: string]: ${x.rest} }`
         const READONLY_OPEN = isReadonly(input) ? 'Readonly<' : ''
         const READONLY_CLOSE = isReadonly(input) ? '>' : ''

--- a/packages/zod-types/src/utils.ts
+++ b/packages/zod-types/src/utils.ts
@@ -116,28 +116,28 @@ export const Warn = {
 
 export const isOptional = tagged('optional')
 
-export function isOptionalDeep(x: unknown): boolean {
+export function hasOptional(x: unknown): boolean {
   switch (true) {
     default: return false
     case tagged('optional', x): return true
-    case tagged('union', x): return x._zod.def.options.some(isOptionalDeep)
-    case tagged('readonly', x): return isOptionalDeep(x._zod.def.innerType)
-    case tagged('nullable', x): return isOptionalDeep(x._zod.def.innerType)
-    case tagged('pipe', x): return isOptionalDeep(x._zod.def.out)
-    case tagged('lazy', x): return isOptionalDeep(x._zod.def.getter())
+    case tagged('union', x): return x._zod.def.options.some(hasOptional)
+    case tagged('readonly', x): return hasOptional(x._zod.def.innerType)
+    case tagged('nullable', x): return hasOptional(x._zod.def.innerType)
+    case tagged('pipe', x): return hasOptional(x._zod.def.out)
+    case tagged('lazy', x): return hasOptional(x._zod.def.getter())
   }
 }
 
-export function isDefaultDeep(x: unknown): boolean {
+export function hasDefault(x: unknown): boolean {
   switch (true) {
     default: return false
     case tagged('default', x): return true
-    case tagged('union', x): return x._zod.def.options.some(isDefaultDeep)
-    case tagged('readonly', x): return isDefaultDeep(x._zod.def.innerType)
-    case tagged('nullable', x): return isDefaultDeep(x._zod.def.innerType)
-    case tagged('optional', x): return isDefaultDeep(x._zod.def.innerType)
-    case tagged('pipe', x): return isDefaultDeep(x._zod.def.out)
-    case tagged('lazy', x): return isDefaultDeep(x._zod.def.getter())
+    case tagged('union', x): return x._zod.def.options.some(hasDefault)
+    case tagged('readonly', x): return hasDefault(x._zod.def.innerType)
+    case tagged('nullable', x): return hasDefault(x._zod.def.innerType)
+    case tagged('optional', x): return hasDefault(x._zod.def.innerType)
+    case tagged('pipe', x): return hasDefault(x._zod.def.out)
+    case tagged('lazy', x): return hasDefault(x._zod.def.getter())
   }
 }
 
@@ -188,8 +188,10 @@ export function getTags(xs: readonly unknown[]): Discriminated | null {
           }
         }
       })
-      if (withTags.every((_) => _ !== null) && withTags.length === seen.size) return [discriminant, withTags]
-      else return null
+      if (withTags.every((_) => _ !== null) && withTags.length === seen.size)
+        return [discriminant, withTags]
+      else
+        return null
     }
   }
 }

--- a/packages/zod/src/deep-nodefaults.ts
+++ b/packages/zod/src/deep-nodefaults.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 import { fn } from '@traversable/registry'
-import { F, tagged, isOptionalDeep, isDefaultDeep } from '@traversable/zod-types'
+import { F, tagged, hasOptional, hasDefault } from '@traversable/zod-types'
 
 import { toString } from './to-string.js'
 
@@ -88,8 +88,8 @@ export function deepNoDefaults<T extends z.ZodType>(
         return z.object(
           fn.map(
             x._zod.def.shape,
-            (v, k) => isOptionalDeep(v) ? v
-              : opts.replaceWithOptional && isDefaultDeep(original._zod.def.shape[k]) ? z.optional(v)
+            (v, k) => hasOptional(v) ? v
+              : opts.replaceWithOptional && hasDefault(original._zod.def.shape[k]) ? z.optional(v)
                 : v
           )
         )

--- a/packages/zod/src/exports.ts
+++ b/packages/zod/src/exports.ts
@@ -1,4 +1,4 @@
-export { fold, isOptional, isOptionalDeep, tagged, typeof, isNullary, F } from '@traversable/zod-types'
+export { F, fold, isNullary, isOptional, hasDefault, hasOptional, tagged, typeof } from '@traversable/zod-types'
 
 export { RAISE_ISSUE_URL, VERSION, ZOD_CHANGELOG, ZOD_VERSION } from './version.js'
 export { check } from './check.js'

--- a/packages/zod/src/to-type.ts
+++ b/packages/zod/src/to-type.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { escape, escapeJsDoc, parseKey } from '@traversable/registry'
-import { hasTypeName, tagged, F, isOptionalDeep, Invariant } from '@traversable/zod-types'
+import { hasTypeName, tagged, F, hasOptional, Invariant } from '@traversable/zod-types'
 import { Json } from '@traversable/json'
 
 export type WithOptionalTypeName = {
@@ -268,7 +268,7 @@ const compile = F.compile<string>((x, ix, input) => {
     case tagged('object')(x): {
       if (!tagged('object', input)) return Invariant.IllegalState('toType', 'Expected input to be an object schema', input)
       const { catchall, shape } = x._zod.def
-      const OPT = Object.entries((input as z.ZodObject)._zod.def.shape).filter(([, v]) => isOptionalDeep(v)).map(([k]) => k)
+      const OPT = Object.entries((input as z.ZodObject)._zod.def.shape).filter(([, v]) => hasOptional(v)).map(([k]) => k)
       const xs = Object.entries(shape).map(
         ([k, v]) => {
           const { description, example } = input._zod.def.shape[k].meta?.() || {}
@@ -293,7 +293,7 @@ const compile = F.compile<string>((x, ix, input) => {
     case tagged('tuple')(x): {
       const { items, rest } = x._zod.def
       const and = typeof rest === 'string' ? `, ...${rest}[]` : ''
-      const lastRequiredIndex = (input as z.ZodTuple)._zod.def.items.findLastIndex((x) => !isOptionalDeep(x))
+      const lastRequiredIndex = (input as z.ZodTuple)._zod.def.items.findLastIndex((x) => !hasOptional(x))
       const req = lastRequiredIndex === -1 ? [] : items.slice(0, lastRequiredIndex + 1)
       const opt = lastRequiredIndex === -1 ? items : items.slice(lastRequiredIndex + 1)
       const body = [...req, ...opt.map((item) => `_?: ${item.startsWith('undefined | ') ? item.substring('undefined | '.length) : item}`)]

--- a/packages/zod/test/utils.test.ts
+++ b/packages/zod/test/utils.test.ts
@@ -6,6 +6,8 @@ vi.describe('〖⛳️〗‹‹‹ ❲@traversable/zod❳', () => {
   vi.test('〖⛳️〗› ❲zx.isOptional❳', () => {
     vi.expect.soft(zx.isOptional(z.optional(z.string()))).to.be.true
     vi.expect.soft(z.tuple([z.boolean(), z.optional(z.boolean())])._zod.def.items.filter(zx.isOptional)).to.have.lengthOf(1)
-    vi.assert.isFalse(zx.isOptionalDeep(z.object({ a: z.undefined() })._zod.def.shape.a))
+  })
+  vi.test('〖⛳️〗› ❲zx.hasOptional❳', () => {
+    vi.assert.isFalse(zx.hasOptional(z.object({ a: z.undefined() })._zod.def.shape.a))
   })
 })


### PR DESCRIPTION
Fixes #458 
Closes #459 
Closes #460