### PR TITLE
feat(valibot): re-exports types and `tagged` from `@traversable/valibot-types`

### DIFF
--- a/.changeset/rare-buttons-enjoy.md
+++ b/.changeset/rare-buttons-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@traversable/valibot": patch
+---
+
+feat(valibot): re-exports types and `tagged` from `@traversable/valibot-types`

--- a/packages/valibot/src/exports.ts
+++ b/packages/valibot/src/exports.ts
@@ -1,7 +1,17 @@
+export type {
+  Algebra,
+  AnyTag,
+  AnyValibotSchema,
+  Fold,
+  Index,
+  V,
+} from '@traversable/valibot-types'
 export {
+  F,
   toString,
   fold,
   Functor,
+  tagged,
 } from '@traversable/valibot-types'
 
 export { VERSION } from './version.js'


### PR DESCRIPTION
Closes #489