### PR TITLE
fix(typebox,typebox-types): fixes bug where `box.toString` was not properly escaping string values inside `T.Literal`

### DIFF
--- a/.changeset/every-flowers-wear.md
+++ b/.changeset/every-flowers-wear.md
@@ -1,0 +1,7 @@
+---
+"@traversable/typebox": patch
+"@traversable/valibot": patch
+"@traversable/zod": patch
+---
+
+test(typebox,valibot,zod): adds fuzz tests for `.toString` transformers

--- a/.changeset/whole-shrimps-throw.md
+++ b/.changeset/whole-shrimps-throw.md
@@ -1,0 +1,5 @@
+---
+"@traversable/typebox": patch
+---
+
+fix(typebox,typebox-types): fixes bug where `box.toString` was not properly escaping string values inside `T.Literal`

--- a/packages/typebox/src/to-string.ts
+++ b/packages/typebox/src/to-string.ts
@@ -11,6 +11,7 @@ import {
   Object_keys,
   Object_values,
   parseKey,
+  escape,
 } from '@traversable/registry'
 import type { Type } from '@traversable/typebox-types'
 import { F } from '@traversable/typebox-types'
@@ -105,7 +106,7 @@ const interpret = (options?: toString.Options) => F.fold<string>((x) => {
     case F.tagged('string')(x): return `${T}.String(${applyStringBounds(x)})`
     case F.tagged('date')(x): return `${T}.Date()`
     case F.tagged('optional')(x): return `${T}.Optional(${x.schema})`
-    case F.tagged('literal')(x): return `${T}.Literal(${typeof x.const === 'string' ? `"${x.const}"` : x.const})`
+    case F.tagged('literal')(x): return `${T}.Literal(${typeof x.const === 'string' ? `"${escape(x.const)}"` : x.const})`
     case F.tagged('array')(x): return `${T}.Array(${x.items}${applyArrayBounds(x)})`
     case F.tagged('allOf')(x): return `${T}.Intersect([${x.allOf.join(',')}])`
     case F.tagged('anyOf')(x): return `${T}.Union([${x.anyOf.join(',')}])`

--- a/packages/typebox/test/to-string.fuzz.test.ts
+++ b/packages/typebox/test/to-string.fuzz.test.ts
@@ -1,0 +1,69 @@
+import * as vi from 'vitest'
+import * as T from '@sinclair/typebox'
+import { Check } from '@sinclair/typebox/value'
+import * as fc from 'fast-check'
+import prettier from '@prettier/sync'
+import { box } from '@traversable/typebox'
+import {
+  seedToSchema,
+  seedToValidData,
+  seedToInvalidData,
+  SeedInvalidDataGenerator,
+} from '@traversable/typebox-test'
+
+const format = (src: string) => prettier.format(src, { parser: 'typescript', semi: false })
+
+type LoggerDeps = {
+  schema: T.TSchema
+  data: unknown
+  error: unknown
+}
+
+function logger({ schema, data, error }: LoggerDeps) {
+  console.group('FAILURE: property test for box.toString')
+  console.error('Error:', error)
+  console.debug('schema:', format(box.toString(schema)))
+  console.debug('data:', data)
+  console.groupEnd()
+}
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traversable/typebox❳: fuzz tests', () => {
+  vi.test('〖⛳️〗› ❲box.toString❳: roundtrip property', () => {
+    fc.assert(
+      fc.property(
+        SeedInvalidDataGenerator,
+        (seed) => {
+          const inputSchema = seedToSchema(seed)
+          const validData = seedToValidData(seed)
+          const invalidData = seedToInvalidData(seed)
+          const outputSchema: T.TSchema = eval(`(() => {
+            const T = require('@sinclair/typebox')
+            return ${box.toString(inputSchema)}
+          })()`)
+
+          // sanity check:
+          vi.assert.isTrue(Check(inputSchema, [], validData))
+          vi.assert.isFalse(Check(inputSchema, [], invalidData))
+
+          try {
+            vi.assert.isTrue(Check(outputSchema, [], validData))
+          } catch (error) {
+            logger({ schema: outputSchema, data: validData, error })
+            vi.expect.fail('v.parse(outputSchema, invalidData) succeeded')
+          }
+
+          try {
+            vi.assert.isFalse(Check(outputSchema, [], invalidData))
+          } catch (error) {
+            logger({ schema: outputSchema, data: validData, error })
+            vi.expect.fail('v.parse(outputSchema, validData) failed')
+          }
+        }
+      ),
+      {
+        endOnFailure: true,
+        // numRuns: 10_000,
+      }
+    )
+  })
+})

--- a/packages/valibot/test/to-string.fuzz.test.ts
+++ b/packages/valibot/test/to-string.fuzz.test.ts
@@ -1,0 +1,68 @@
+import * as vi from 'vitest'
+import * as v from 'valibot'
+import * as fc from 'fast-check'
+import prettier from '@prettier/sync'
+import { vx } from '@traversable/valibot'
+import {
+  seedToSchema,
+  seedToValidData,
+  seedToInvalidData,
+  SeedInvalidDataGenerator,
+} from '@traversable/valibot-test'
+
+const format = (src: string) => prettier.format(src, { parser: 'typescript', semi: false })
+
+type LoggerDeps = {
+  schema: v.BaseSchema<any, any, any>
+  data: unknown
+  error: unknown
+}
+
+function logger({ schema, data, error }: LoggerDeps) {
+  console.group('FAILURE: property test for vx.toString')
+  console.error('Error:', error)
+  console.debug('schema:', format(vx.toString(schema)))
+  console.debug('data:', data)
+  console.groupEnd()
+}
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traversable/valibot❳: fuzz tests', () => {
+  vi.test('〖⛳️〗› ❲vx.toString❳: roundtrip property', () => {
+    fc.assert(
+      fc.property(
+        SeedInvalidDataGenerator,
+        (seed) => {
+          const inputSchema = seedToSchema(seed)
+          const validData = seedToValidData(seed)
+          const invalidData = seedToInvalidData(seed)
+          const outputSchema: vx.AnyValibotSchema = eval(`(() => {
+            const v = require('valibot')
+            return ${vx.toString(inputSchema)}
+          })()`)
+
+          // sanity check:
+          vi.assert.throws(() => v.parse(inputSchema, invalidData))
+          vi.assert.doesNotThrow(() => v.parse(inputSchema, validData))
+
+          try {
+            vi.assert.throws(() => v.parse(outputSchema, invalidData))
+          } catch (error) {
+            logger({ schema: outputSchema, data: validData, error })
+            vi.expect.fail('v.parse(outputSchema, invalidData) succeeded')
+          }
+
+          try {
+            vi.assert.doesNotThrow(() => v.parse(outputSchema, validData))
+          } catch (error) {
+            logger({ schema: outputSchema, data: validData, error })
+            vi.expect.fail('v.parse(outputSchema, validData) failed')
+          }
+        }
+      ),
+      {
+        endOnFailure: true,
+        // numRuns: 10_000,
+      }
+    )
+  })
+})

--- a/packages/zod/test/to-string.fuzz.test.ts
+++ b/packages/zod/test/to-string.fuzz.test.ts
@@ -1,0 +1,97 @@
+import * as vi from 'vitest'
+import * as z from 'zod'
+import * as fc from 'fast-check'
+import prettier from '@prettier/sync'
+import { fn } from '@traversable/registry'
+import { zx } from '@traversable/zod'
+import {
+  seedToSchema,
+  seedToValidData,
+  seedToInvalidData,
+  SeedGenerator,
+} from '@traversable/zod-test'
+
+const format = (src: string) => prettier.format(src, { parser: 'typescript', semi: false })
+
+type LoggerDeps = {
+  schema: z.ZodType
+  data: unknown
+  error: unknown
+}
+
+function logger({ schema, data, error }: LoggerDeps) {
+  console.group('FAILURE: property test for zx.toString')
+  console.error('Error:', error)
+  console.debug('schema:', format(zx.toString(schema)))
+  console.debug('data:', data)
+  console.groupEnd()
+}
+
+const Generator = fn.pipe(
+  SeedGenerator({
+    exclude: [
+      'any',
+      'catch',
+      'custom',
+      'default',
+      'prefault',
+      'never',
+      'nonoptional',
+      'pipe',
+      'promise',
+      'symbol',
+      'transform',
+      'unknown',
+      'success',
+      'prefault',
+      'template_literal',
+    ]
+  }),
+  ($) => fc.oneof(
+    $.object,
+    $.tuple,
+    $.array,
+    $.record,
+  )
+)
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traversable/zod❳: fuzz tests', () => {
+  vi.test('〖⛳️〗› ❲zx.toString❳: roundtrip property', () => {
+    fc.assert(
+      fc.property(
+        Generator,
+        (seed) => {
+          const inputSchema = seedToSchema(seed)
+          const validData = seedToValidData(seed)
+          const invalidData = seedToInvalidData(seed)
+          const outputSchema: z.ZodType = eval(`(() => {
+            const z = require('zod')
+            return ${zx.toString(inputSchema)}
+          })()`)
+
+          // sanity check:
+          vi.assert.throws(() => inputSchema.parse(invalidData))
+          vi.assert.doesNotThrow(() => inputSchema.parse(validData))
+
+          try {
+            vi.assert.throws(() => outputSchema.parse(invalidData))
+          } catch (error) {
+            logger({ schema: outputSchema, data: validData, error })
+            vi.expect.fail('v.parse(outputSchema, invalidData) succeeded')
+          }
+
+          try {
+            vi.assert.doesNotThrow(() => outputSchema.parse(validData))
+          } catch (error) {
+            logger({ schema: outputSchema, data: validData, error })
+            vi.expect.fail('v.parse(outputSchema, validData) failed')
+          }
+        }
+      ),
+      {
+        endOnFailure: true,
+        // numRuns: 5_000,
+      }
+    )
+  })
+})


### PR DESCRIPTION
Closes #517