### PR TITLE
feat(zod): adds `zx.convertCaseCodec`, `zx.deepCamelCaseCodec` and `zx.deepSnakeCaseCodec`

### DIFF
--- a/.changeset/grumpy-buckets-like.md
+++ b/.changeset/grumpy-buckets-like.md
@@ -2,4 +2,18 @@
 "@traversable/zod": patch
 ---
 
-feat(zod): adds `zx.convertCaseCodec`, `zx.deepCamelCaseCodec` and `zx.deepSnakeCaseCodec` (#522)
+feat(zod): 
+
+### new features
+
+- `zx.convertCaseCodec` 
+- `zx.deepCamelCaseCodec` (experimental)
+- `zx.deepSnakeCaseCodec` (experimental)
+
+This change adds a new transformer for the `@traversable/zod` package that uses a new feature that was added in zod v4: [codecs](https://zod.dev/codecs).
+
+Because of how easy `zx.fold` is to work with, implementing `zx.convertCaseCodec` was relatively simple, and took me about an hour.
+
+Usually I'd fuzz test the hell out of it before publishing, but this time I figured I'd release these early, to have a chance for users to use it and provide feedback before I go through the trouble.
+
+If you use this and run into any problems, please don't hesitate to [open an issue](https://github.com/traversable/schema/issues)!

--- a/.changeset/grumpy-buckets-like.md
+++ b/.changeset/grumpy-buckets-like.md
@@ -1,0 +1,5 @@
+---
+"@traversable/zod": patch
+---
+
+feat(zod): adds `zx.convertCaseCodec`, `zx.deepCamelCaseCodec` and `zx.deepSnakeCaseCodec` (#522)

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -518,6 +518,9 @@ Convert a zod schema into a codec that **decodes any objects's keys to camel cas
 #### Example
 
 ```typescript
+import * as z from 'zod'
+import { zx } from '@traversable/zod'
+
 const CAMEL = zx.deepCamelCaseCodec(
   z.object({
     abc_def: z.string(),
@@ -610,6 +613,9 @@ Convert a zod schema into a codec that **decodes any objects's keys to snake cas
 #### Example
 
 ```typescript
+import * as z from 'zod'
+import { zx } from '@traversable/zod'
+
 const SNAKE = zx.deepSnakeCaseCodec(
   z.object({
     abc_def: z.string(),

--- a/packages/zod/src/convert-case-codec.ts
+++ b/packages/zod/src/convert-case-codec.ts
@@ -1,0 +1,46 @@
+import * as z from 'zod'
+import { F, tagged } from '@traversable/zod-types'
+import { fn } from '@traversable/registry'
+
+const DASH = new RegExp('[-_]', 'g')
+const DASH_BOUNDARY = new RegExp('([-_][a-z])', 'g')
+const WORD_BOUNDARY = new RegExp('([a-z])([A-Z])', 'g')
+
+export function camelCase(x: string) {
+  return x.replace(DASH_BOUNDARY, (c) => c.toUpperCase().replace(DASH, ''))
+}
+
+export function snakeCase(x: string) {
+  return x.replace(WORD_BOUNDARY, "$1_$2").toLowerCase()
+}
+
+export type ConvertCase = {
+  decodeKeys(k: string): string,
+  encodeKeys(k: string): string
+}
+
+export function convertCaseCodec({ decodeKeys, encodeKeys }: ConvertCase): <T extends z.ZodType>(type: T) => z.ZodType
+export function convertCaseCodec({ decodeKeys, encodeKeys }: ConvertCase): <T extends z.core.$ZodType>(type: T) => z.core.$ZodType
+export function convertCaseCodec({ decodeKeys, encodeKeys }: ConvertCase) {
+  const decode = <T>(x: { [k: string]: T }) => Object.fromEntries(Object.entries(x).map(([k, v]) => [decodeKeys(k), v]))
+  const encode = <T>(x: { [k: string]: T }) => Object.fromEntries(Object.entries(x).map(([k, v]) => [encodeKeys(k), v]))
+  return F.fold<z.core.$ZodType>((x, _, original) => {
+    switch (true) {
+      case tagged('object')(x) && tagged('object', original): {
+        const { shape, catchall } = original._zod.def
+        const encoder = !catchall
+          ? z.object(encode(fn.map(shape, (v) => z.clone(v, v._zod.def))))
+          : z.object(encode(fn.map(shape, (v) => z.clone(v, v._zod.def)))).catchall(catchall)
+        const decoder = !catchall
+          ? z.object(decode(x._zod.def.shape))
+          : z.object(decode(x._zod.def.shape)).catchall(catchall)
+        return z.codec(encoder, decoder, { decode, encode })
+      }
+      case tagged('transform')(x): return x as never
+      default: return z.clone(original, x._zod.def as z.core.$ZodTypeDef)
+    }
+  })
+}
+
+export const deepSnakeCaseCodec = convertCaseCodec({ decodeKeys: snakeCase, encodeKeys: camelCase })
+export const deepCamelCaseCodec = convertCaseCodec({ decodeKeys: camelCase, encodeKeys: snakeCase })

--- a/packages/zod/src/exports.ts
+++ b/packages/zod/src/exports.ts
@@ -21,6 +21,15 @@ export { toPaths } from './to-paths.js'
 export { toString } from './to-string.js'
 export { toType } from './to-type.js'
 
+export type { ConvertCase } from './convert-case-codec.js'
+export {
+  convertCaseCodec,
+  deepCamelCaseCodec,
+  deepSnakeCaseCodec,
+  camelCase,
+  snakeCase,
+} from './convert-case-codec.js'
+
 export {
   /** @experimental */
   makeLens,

--- a/packages/zod/test/convert-case-codec.test.ts
+++ b/packages/zod/test/convert-case-codec.test.ts
@@ -1,0 +1,364 @@
+import * as vi from 'vitest'
+import { z } from 'zod'
+import { zx } from '@traversable/zod'
+import prettier from '@prettier/sync'
+
+const format = (src: string) => prettier.format(src, { parser: 'typescript', printWidth: 60 })
+
+vi.describe('〖⛳️〗‹‹‹ ❲@traversable/zod❳', () => {
+  vi.test('〖⛳️〗› ❲camelCase❳', () => {
+    vi.expect.soft(
+      zx.camelCase('abc_def')
+    ).toMatchInlineSnapshot
+      (`"abcDef"`)
+  })
+
+  vi.test('〖⛳️〗› ❲snakeCase❳', () => {
+    vi.expect.soft(
+      zx.snakeCase('abcDef')
+    ).toMatchInlineSnapshot
+      (`"abc_def"`)
+  })
+
+  vi.test('〖⛳️〗› ❲zx.convertCaseCodec❳', () => {
+    const schema_01 = z.object({
+      abc: z.string(),
+      def: z.object({
+        ghi: z.array(
+          z.object({
+            jkl: z.boolean()
+          })
+        )
+      })
+    })
+
+    const ALL_CAPS = zx.convertCaseCodec({
+      decodeKeys: (k) => k.toUpperCase(),
+      encodeKeys: (k) => k.toLowerCase(),
+    })
+
+    vi.expect.soft(
+      ALL_CAPS(schema_01).parse({
+        abc: 'hi how are you',
+        def: {
+          ghi: [
+            {
+              jkl: false
+            },
+            {
+              jkl: true
+            },
+          ]
+        }
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "ABC": "hi how are you",
+        "DEF": {
+          "GHI": [
+            {
+              "JKL": false,
+            },
+            {
+              "JKL": true,
+            },
+          ],
+        },
+      }
+    `)
+
+
+    vi.expect.soft(
+      ALL_CAPS(schema_01).decode({
+        abc: 'hi how are you',
+        def: {
+          ghi: [
+            {
+              jkl: false
+            },
+            {
+              jkl: true
+            },
+          ]
+        }
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "ABC": "hi how are you",
+        "DEF": {
+          "GHI": [
+            {
+              "JKL": false,
+            },
+            {
+              "JKL": true,
+            },
+          ],
+        },
+      }
+    `)
+
+    vi.expect.soft(
+      ALL_CAPS(schema_01).encode({
+        "ABC": "hi how are you",
+        "DEF": {
+          "GHI": [
+            {
+              "JKL": false,
+            },
+            {
+              "JKL": true,
+            },
+          ],
+        },
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "abc": "hi how are you",
+        "def": {
+          "ghi": [
+            {
+              "jkl": false,
+            },
+            {
+              "jkl": true,
+            },
+          ],
+        },
+      }
+    `)
+  })
+
+  vi.test('〖⛳️〗› ❲zx.deepCamelCaseCodec❳', () => {
+    const CAMEL = zx.deepCamelCaseCodec(
+      z.object({
+        abc_def: z.string(),
+        ghi_jkl: z.object({
+          mno_pqr: z.number(),
+          stu_vwx: z.array(
+            z.object({
+              y_z: z.boolean()
+            })
+          )
+        })
+      })
+    )
+
+    vi.expect.soft(
+      CAMEL.parse({
+        abc_def: 'hi how are you',
+        ghi_jkl: {
+          mno_pqr: 123,
+          stu_vwx: [
+            {
+              y_z: true
+            },
+            {
+              y_z: false
+            }
+          ]
+        }
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "abcDef": "hi how are you",
+        "ghiJkl": {
+          "mnoPqr": 123,
+          "stuVwx": [
+            {
+              "yZ": true,
+            },
+            {
+              "yZ": false,
+            },
+          ],
+        },
+      }
+    `)
+
+    vi.expect.soft(
+      CAMEL.decode({
+        abc_def: 'hi how are you',
+        ghi_jkl: {
+          mno_pqr: 123,
+          stu_vwx: [
+            {
+              y_z: true
+            },
+            {
+              y_z: false
+            }
+          ]
+        }
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "abcDef": "hi how are you",
+        "ghiJkl": {
+          "mnoPqr": 123,
+          "stuVwx": [
+            {
+              "yZ": true,
+            },
+            {
+              "yZ": false,
+            },
+          ],
+        },
+      }
+    `)
+
+    vi.expect.soft(
+      CAMEL.encode({
+        "abcDef": "hi how are you",
+        "ghiJkl": {
+          "mnoPqr": 123,
+          "stuVwx": [
+            {
+              "yZ": true,
+            },
+            {
+              "yZ": false,
+            },
+          ],
+        },
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "abc_def": "hi how are you",
+        "ghi_jkl": {
+          "mno_pqr": 123,
+          "stu_vwx": [
+            {
+              "y_z": true,
+            },
+            {
+              "y_z": false,
+            },
+          ],
+        },
+      }
+    `)
+  })
+
+  vi.test('〖⛳️〗› ❲zx.deepSnakeCaseCodec❳', () => {
+    const SNAKE = zx.deepSnakeCaseCodec(
+      z.object({
+        abcDef: z.string(),
+        ghiJkl: z.object({
+          mnoPqr: z.number(),
+          stuVwx: z.array(
+            z.object({
+              yZ: z.boolean()
+            })
+          )
+        })
+      })
+    )
+
+    vi.expect.soft(
+      SNAKE.parse({
+        "abcDef": "hi how are you",
+        "ghiJkl": {
+          "mnoPqr": 123,
+          "stuVwx": [
+            {
+              "yZ": true,
+            },
+            {
+              "yZ": false,
+            },
+          ],
+        },
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "abc_def": "hi how are you",
+        "ghi_jkl": {
+          "mno_pqr": 123,
+          "stu_vwx": [
+            {
+              "y_z": true,
+            },
+            {
+              "y_z": false,
+            },
+          ],
+        },
+      }
+    `)
+
+    vi.expect.soft(
+      SNAKE.decode({
+        "abcDef": "hi how are you",
+        "ghiJkl": {
+          "mnoPqr": 123,
+          "stuVwx": [
+            {
+              "yZ": true,
+            },
+            {
+              "yZ": false,
+            },
+          ],
+        },
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "abc_def": "hi how are you",
+        "ghi_jkl": {
+          "mno_pqr": 123,
+          "stu_vwx": [
+            {
+              "y_z": true,
+            },
+            {
+              "y_z": false,
+            },
+          ],
+        },
+      }
+    `)
+
+    vi.expect.soft(
+      SNAKE.encode({
+        "abc_def": "hi how are you",
+        "ghi_jkl": {
+          "mno_pqr": 123,
+          "stu_vwx": [
+            {
+              "y_z": true,
+            },
+            {
+              "y_z": false,
+            },
+          ],
+        },
+      })
+    ).toMatchInlineSnapshot
+      (`
+      {
+        "abcDef": "hi how are you",
+        "ghiJkl": {
+          "mnoPqr": 123,
+          "stuVwx": [
+            {
+              "yZ": true,
+            },
+            {
+              "yZ": false,
+            },
+          ],
+        },
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Closes #522

### new features

- [`zx.convertCaseCodec`](https://github.com/traversable/schema/pull/523/files#diff-ef2dfb995958a86f3f912190b142174c71232a4f89c7103c2247307b8de3acd8R22-R43)
- [`zx.deepCamelCaseCodec`](https://github.com/traversable/schema/pull/523/files#diff-ef2dfb995958a86f3f912190b142174c71232a4f89c7103c2247307b8de3acd8R45) (experimental)
- [`zx.deepSnakeCaseCodec`](https://github.com/traversable/schema/pull/523/files#diff-ef2dfb995958a86f3f912190b142174c71232a4f89c7103c2247307b8de3acd8R46) (experimental)

This change adds a new transformer for the `@traversable/zod` package that uses a new feature that was added in zod v4: [codecs](https://zod.dev/codecs).

Because of how easy `zx.fold` is to work with, implementing `zx.convertCaseCodec` was relatively simple, and took me about an hour.

Usually I'd fuzz test the hell out of it before publishing, but this time I figured I'd release these early, to have a chance for users to use it and provide feedback before I go through the trouble.

> [!NOTE]
> Currently there is no type-level support for these transformers. I'm still trying to decide if doing that would be a good idea.
>
> My current thinking is that it would be better to implement `.writeable` variants (for example, `zx.deepCamelCaseCodec.writeable`) – if we did that, it would be trivial to also generate the to/from types as well using `zx.toType`.

If you use this and run into any problems, please don't hesitate to [open an issue](https://github.com/traversable/schema/issues)!