### PR TITLE
feat(zod): adds `zx.toPath` support for enum records (#554)

### DIFF
--- a/.changeset/funny-onions-return.md
+++ b/.changeset/funny-onions-return.md
@@ -1,0 +1,5 @@
+---
+"@traversable/zod": patch
+---
+
+feat(zod): adds `zx.toPath` support for enum records (#554)

--- a/.changeset/ten-rabbits-care.md
+++ b/.changeset/ten-rabbits-care.md
@@ -1,0 +1,5 @@
+---
+"@traversable/zod-test": patch
+---
+
+docs(zod-test): fixes typo and a few broken links in the README (#550)

--- a/packages/zod-test/README.md
+++ b/packages/zod-test/README.md
@@ -75,15 +75,15 @@ import { zxTest } from '@traversable/zod-test'
 
 ## Table of contents
 
-- [`zxTest.fuzz`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxfuzz)
+- [`zxTest.fuzz`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestfuzz)
 - [`zxTest.seedToSchema`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedtoschema)
 - [`zxTest.seedToValidData`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedtovaliddata)
 - [`zxTest.seedToInvalidData`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedtoinvaliddata)
-- [`zxTest.seedToValidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxseedtovaliddatagenerator)
-- [`zxTest.seedToInvalidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxseedtoinvaliddatagenerator)
+- [`zxTest.seedToValidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedtovaliddatagenerator)
+- [`zxTest.seedToInvalidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedtoinvaliddatagenerator)
 - [`zxTest.SeedGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedgenerator)
-- [`zxTest.SeedValidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxseedvaliddatagenerator)
-- [`zxTest.SeedInvalidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxseedinvaliddatagenerator)
+- [`zxTest.SeedValidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedvaliddatagenerator)
+- [`zxTest.SeedInvalidDataGenerator`](https://github.com/traversable/schema/tree/main/packages/zod-test#zxtestseedinvaliddatagenerator)
 
 
 ### `zxTest.fuzz`
@@ -97,22 +97,23 @@ Override individual arbitraries via the 3rd argument (`overrides`).
 > [!NOTE]
 >
 > `zxTest.fuzz` is the __only__ schema-to-generator function that has itself
-> been fuzz tested to ensure that no matter what schema you give it, the data-generator that `fuzz`
-> returns will always produce valid data.
-
-The only known exceptions are schemas that make it impossible to generate valid data. For example:
-
-- `z.never` 
-- `z.nonoptional(z.undefined())`
-- `z.enum([])`
-- `z.union([])`
-- `z.intersection(z.number(), z.string())`
+> been fuzz tested to ensure that no matter what schema you give it, the data-generator it
+> returns will always produce valid data. 
+>
+> This excludes schemas that make it impossible to generate valid data, for example:
+> 
+> - `z.never` 
+> - `z.nonoptional(z.undefined())`
+> - `z.enum([])`
+> - `z.union([])`
+> - `z.intersection(z.number(), z.string())`
 
 #### Example
 
 ```typescript
 import * as vi from 'vitest'
-import * as fc from 'fast-check' * import { fuzz } from '@traversable/zod-test'
+import * as fc from 'fast-check'
+import { fuzz } from '@traversable/zod-test'
 
 const Schema = z.record(
   z.string(), 

--- a/packages/zod/test/to-paths.test.ts
+++ b/packages/zod/test/to-paths.test.ts
@@ -4,7 +4,7 @@ import { z } from "zod"
 import { zx } from "@traversable/zod"
 
 vi.describe("〖️⛳️〗‹‹‹ ❲@traversable/zod❳: zx.paths", () => {
-  vi.test("〖️⛳️〗› ❲zx.toPaths❳ ", () => {
+  vi.test("〖️⛳️〗› ❲zx.toPaths❳: z.object ", () => {
     vi.expect.soft(zx.toPaths(z.object())).toMatchInlineSnapshot
       (`[]`)
 
@@ -32,6 +32,62 @@ vi.describe("〖️⛳️〗‹‹‹ ❲@traversable/zod❳: zx.paths", () => {
         ],
         [
           "c",
+          "d",
+        ],
+      ]
+    `)
+  })
+
+  vi.test("〖️⛳️〗› ❲zx.toPaths❳: z.record", () => {
+    vi.expect.soft(zx.toPaths(
+      z.record(z.enum([]), z.object({
+        a: z.number(),
+        b: z.object({
+          c: z.string(),
+          d: z.boolean(),
+        }),
+      }))
+    )).toMatchInlineSnapshot
+      (`[]`)
+
+    // https://github.com/traversable/schema/issues/554
+    vi.expect.soft(zx.toPaths(
+      z.record(z.enum(['left', 'right']), z.object({
+        a: z.number(),
+        b: z.object({
+          c: z.string(),
+          d: z.boolean(),
+        }),
+      }))
+    )).toMatchInlineSnapshot
+      (`
+      [
+        [
+          "left",
+          "a",
+        ],
+        [
+          "right",
+          "a",
+        ],
+        [
+          "left",
+          "b",
+          "c",
+        ],
+        [
+          "right",
+          "b",
+          "c",
+        ],
+        [
+          "left",
+          "b",
+          "d",
+        ],
+        [
+          "right",
+          "b",
           "d",
         ],
       ]


### PR DESCRIPTION
Closes #554
Closes #550

### new features

- feat(zod): adds `zx.toPath` support for enum records (#554)

### documentation

- docs(zod-test): fixes typo and a few broken links in the README (#550)

